### PR TITLE
Add pagination support

### DIFF
--- a/example/spotify_dart_example.dart
+++ b/example/spotify_dart_example.dart
@@ -18,4 +18,9 @@ main() async {
 
   var album = await spotify.albums.get('6PEYvIrLYHJ8BvpE5uUChz');
   print(album.name);
+
+  var featuredPlaylists = await spotify.playlists.featured.all();
+  featuredPlaylists.forEach((playlist) {
+    print(playlist.name);
+  });
 }

--- a/lib/spotify_browser.json.g.dart
+++ b/lib/spotify_browser.json.g.dart
@@ -668,6 +668,38 @@ abstract class PlaylistSimpleMapper {
   }
 }
 
+/// Mapper for PlaylistsFeatured
+abstract class PlaylistsFeaturedMapper {
+  /// Converts an instance of PlaylistsFeatured to Map.
+  static Map<String, dynamic> map(PlaylistsFeatured object) {
+    if (object == null) return null;
+    return (new _owl_json.MapBuilder(ordered: false)
+          ..put('message', object.message))
+        .toMap();
+  }
+
+  /// Converts a Map to an instance of PlaylistsFeatured.
+  static PlaylistsFeatured parse(Map<String, dynamic> map) {
+    if (map == null) return null;
+    final PlaylistsFeatured object = new PlaylistsFeatured();
+    object.message = map['message'];
+    return object;
+  }
+
+  /// Converts a JSON string to an instance of PlaylistsFeatured.
+  static PlaylistsFeatured fromJson(String json) {
+    if (json == null || json.isEmpty) return null;
+    final Map<String, dynamic> map = JSON.decoder.convert(json);
+    return parse(map);
+  }
+
+  /// Converts an instance of PlaylistsFeatured to JSON string.
+  static String toJson(PlaylistsFeatured object) {
+    if (object == null) return null;
+    return JSON.encoder.convert(map(object));
+  }
+}
+
 /// Mapper for PlaylistTrack
 abstract class PlaylistTrackMapper {
   /// Converts an instance of PlaylistTrack to Map.

--- a/lib/spotify_io.dart
+++ b/lib/spotify_io.dart
@@ -16,6 +16,7 @@ import 'spotify_io.json.g.dart';
 import 'src/models/token_request.dart';
 import 'src/models/token_request.json.g.dart';
 
+part 'src/models/paging.dart';
 part 'src/models/artist.dart';
 part 'src/models/followers.dart';
 part 'src/models/image.dart';

--- a/lib/spotify_io.dart
+++ b/lib/spotify_io.dart
@@ -27,6 +27,7 @@ part 'src/models/user.dart';
 part 'src/models/audio_feature.dart';
 
 part 'src/endpoints/endpoint_base.dart';
+part 'src/endpoints/endpoint_paging.dart';
 part 'src/endpoints/artists.dart';
 part 'src/endpoints/albums.dart';
 part 'src/endpoints/tracks.dart';

--- a/lib/spotify_io.json.g.dart
+++ b/lib/spotify_io.json.g.dart
@@ -14,6 +14,50 @@ import 'dart:convert';
 // ignore: unused_import, library_prefixes
 import 'package:owl/util/json/core.dart' as _owl_json;
 
+/// Mapper for Paging
+abstract class PagingMapper {
+  /// Converts an instance of Paging to Map.
+  static Map<String, dynamic> map(Paging object) {
+    if (object == null) return null;
+    return (new _owl_json.MapBuilder(ordered: false)
+          ..put('href', object.href)
+          ..put('items', object.itemsNative)
+          ..put('limit', object.limit)
+          ..put('next', object.next)
+          ..put('offset', object.offset)
+          ..put('previous', object.previous)
+          ..put('total', object.total))
+        .toMap();
+  }
+
+  /// Converts a Map to an instance of Paging.
+  static Paging parse(Map<String, dynamic> map) {
+    if (map == null) return null;
+    final Paging object = new Paging();
+    object.href = map['href'];
+    object.itemsNative = map['items'];
+    object.limit = map['limit'];
+    object.next = map['next'];
+    object.offset = map['offset'];
+    object.previous = map['previous'];
+    object.total = map['total'];
+    return object;
+  }
+
+  /// Converts a JSON string to an instance of Paging.
+  static Paging fromJson(String json) {
+    if (json == null || json.isEmpty) return null;
+    final Map<String, dynamic> map = JSON.decoder.convert(json);
+    return parse(map);
+  }
+
+  /// Converts an instance of Paging to JSON string.
+  static String toJson(Paging object) {
+    if (object == null) return null;
+    return JSON.encoder.convert(map(object));
+  }
+}
+
 /// Mapper for Artist
 abstract class ArtistMapper {
   /// Converts an instance of Artist to Map.
@@ -663,6 +707,38 @@ abstract class PlaylistSimpleMapper {
 
   /// Converts an instance of PlaylistSimple to JSON string.
   static String toJson(PlaylistSimple object) {
+    if (object == null) return null;
+    return JSON.encoder.convert(map(object));
+  }
+}
+
+/// Mapper for PlaylistsFeatured
+abstract class PlaylistsFeaturedMapper {
+  /// Converts an instance of PlaylistsFeatured to Map.
+  static Map<String, dynamic> map(PlaylistsFeatured object) {
+    if (object == null) return null;
+    return (new _owl_json.MapBuilder(ordered: false)
+          ..put('message', object.message))
+        .toMap();
+  }
+
+  /// Converts a Map to an instance of PlaylistsFeatured.
+  static PlaylistsFeatured parse(Map<String, dynamic> map) {
+    if (map == null) return null;
+    final PlaylistsFeatured object = new PlaylistsFeatured();
+    object.message = map['message'];
+    return object;
+  }
+
+  /// Converts a JSON string to an instance of PlaylistsFeatured.
+  static PlaylistsFeatured fromJson(String json) {
+    if (json == null || json.isEmpty) return null;
+    final Map<String, dynamic> map = JSON.decoder.convert(json);
+    return parse(map);
+  }
+
+  /// Converts an instance of PlaylistsFeatured to JSON string.
+  static String toJson(PlaylistsFeatured object) {
     if (object == null) return null;
     return JSON.encoder.convert(map(object));
   }

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2017, rinukkusu. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+part of spotify;
+
+abstract class EndpointPaging extends EndpointBase {
+  EndpointPaging(SpotifyApiBase api) : super(api);
+
+  Pages<T> _getPages<T>(String path,
+      ParserFunction<T> pageItemParser,
+      [
+        String pageKey = null,
+        ParserFunction<Object> pageContainerParser = null
+      ]) =>
+      new Pages(_api, path, pageItemParser, pageKey, pageContainerParser);
+}
+
+class Page<T> {
+  Paging<T> _paging;
+  Iterable<T> _items;
+  Object _container;
+
+  Page(this._paging, ParserFunction<T> pageItemParser,
+      [Object pageContainer = null]) {
+    _items = _paging.itemsNative.map(pageItemParser);
+    _container = pageContainer;
+  }
+
+  /// The offset-based paging object is a container for a set of objects. It
+  /// contains a key called items (whose value is an array of the requested
+  /// objects) along with other keys like previous, next and limit that can be
+  /// useful in future calls.
+  Paging<T> get metadata => _paging;
+
+  /// The requested data
+  Iterable<T> get items => _items;
+
+  /// The object containing this page, if applicable
+  Object get container => _container;
+
+  bool get isLast => _paging.offset + _paging.limit >= _paging.total;
+  int get nextOffset => _paging.offset + _paging.limit;
+}
+
+class Pages<T> {
+  static const defaultLimit = 20;
+
+  SpotifyApiBase _api;
+  String _path;
+  ParserFunction<T> _pageMapper;
+  ParserFunction<Object> _pageContainerMapper;
+  String _pageKey;
+  List<Page<T>> _bufferedPages = [];
+  bool _cancelled = false;
+
+  Pages(this._api, this._path, this._pageMapper,
+      [this._pageKey = null, this._pageContainerMapper = null]) {
+    if (_pageKey != null && _pageContainerMapper == null) {
+      throw new ArgumentError.notNull('_pageContainerMapper');
+    } else if (_pageKey == null && _pageContainerMapper != null) {
+      throw new ArgumentError.notNull('_pageKey');
+    }
+  }
+
+  Future<Page<T>> first([int limit = defaultLimit]) {
+    return _getPage(limit, 0);
+  }
+
+  Future<Iterable<T>> all([int limit = defaultLimit]) {
+    return stream(limit)
+        .map((page) => page.items)
+        .toList()
+        .then((pages) => pages.expand((page) => page));
+  }
+
+  Stream<Page<T>> stream([int limit = defaultLimit]) {
+    StreamController<Page<T>> stream;
+
+    void handlePageAndGetNext(Page<T> page) {
+      if (_cancelled) {
+        stream.close();
+        return;
+      }
+
+      if (stream.isPaused) {
+        _bufferedPages.add(page);
+      } else {
+        stream.add(page);
+      }
+
+      // If this is the last page then end the stream
+      if (page.isLast) {
+        if (!stream.isPaused) {
+          stream.close();
+        }
+        return;
+      }
+
+      // Otherwise get the next page
+      _getPage(limit, page.nextOffset).then(handlePageAndGetNext);
+    }
+
+    stream = new StreamController<Page<T>>(
+      onListen: () {
+        var firstPage = first(limit);
+        firstPage.then(handlePageAndGetNext);
+      },
+      onCancel: () {
+        _cancelled = true;
+        return new Future.value(true);
+      },
+      onResume: () {
+        _bufferedPages.forEach(stream.add);
+        if (_bufferedPages.last.isLast) {
+          stream.close();
+        }
+        _bufferedPages.clear();
+      }
+    );
+    return stream.stream;
+  }
+
+  Future<Page<T>> _getPage(int limit, int offset) async {
+    var pathDelimiter = _path.contains('?') ? '&' : '?';
+    var path = '$_path${pathDelimiter}limit=$limit&offset=$offset';
+
+    var map = await _api._get(path)
+        .then(JSON.decode);
+    if (_pageContainerMapper == null) {
+      var paging = PagingMapper.parse(map);
+      return new Page(paging, _pageMapper);
+    } else {
+      var paging = PagingMapper.parse(map[_pageKey]);
+      var container = _pageContainerMapper(map);
+      return new Page(paging, _pageMapper, container);
+    }
+  }
+}

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -124,8 +124,9 @@ class Pages<T> {
     var pathDelimiter = _path.contains('?') ? '&' : '?';
     var path = '$_path${pathDelimiter}limit=$limit&offset=$offset';
 
-    var map = await _api._get(path)
-        .then(JSON.decode);
+    var json = await _api._get(path);
+    var map = JSON.decode(json);
+
     if (_pageContainerMapper == null) {
       var paging = PagingMapper.parse(map);
       return new Page(paging, _pageMapper);

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -3,25 +3,20 @@
 
 part of spotify;
 
-class Playlists extends EndpointBase {
+class Playlists extends EndpointPaging {
   @override
   String get _path => 'v1/browse';
 
   Playlists(SpotifyApiBase api) : super(api);
 
-  Future<Iterable<Playlist>> featured() async {
-    var json = await _api._get('$_path/featured-playlists');
-    var map = JSON.decode(json);
+   Pages<PlaylistSimple> get featured {
+     return _getPages(
+         '$_path/featured-playlists', PlaylistSimpleMapper.parse,
+         'playlists', PlaylistsFeaturedMapper.parse
+     );
+   }
 
-    var playlistsMap = map['items'] as Iterable<Map>;
-    return playlistsMap.map((m) => PlaylistMapper.parse(m));
-  }
-
-  Future<Iterable<PlaylistSimple>> me() async {
-    var json = await _api._get('v1/me/playlists');
-    var map = JSON.decode(json);
-
-    var playlistsMap = map['items'] as Iterable<Map>;
-    return playlistsMap.map((m) => PlaylistSimpleMapper.parse(m));
+  Pages<PlaylistSimple> get me {
+     return _getPages('v1/me/playlists', PlaylistSimpleMapper.parse);
   }
 }

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -3,7 +3,7 @@
 
 part of spotify;
 
-class Users extends EndpointBase {
+class Users extends EndpointPaging {
   @override
   String get _path => 'v1/users';
 
@@ -19,12 +19,8 @@ class Users extends EndpointBase {
     return UserPublicMapper.fromJson(json);
   }
 
-  Future<Iterable<PlaylistSimple>> playlists(String userId) async {
-    var json = await _api._get('$_path/$userId/playlists');
-    var map = JSON.decode(json);
-
-    var playlistsMap = map['items'] as Iterable<Map>;
-    return playlistsMap.map((m) => PlaylistSimpleMapper.parse(m));
+  Pages<PlaylistSimple> playlists(String userId) {
+    return _getPages('$_path/$userId/playlists', PlaylistSimpleMapper.parse);
   }
 
   Future<Playlist> playlist(String userId, String playlistId) async {
@@ -32,11 +28,10 @@ class Users extends EndpointBase {
     return PlaylistMapper.fromJson(json);
   }
 
-  Future<Iterable<PlaylistTrack>> playlistTracks(String userId, String playlistId) async {
-    var json = await _api._get('$_path/$userId/playlists/$playlistId');
-    var map = JSON.decode(json);
-
-    var playlistsMap = map['items'] as Iterable<Map>;
-    return playlistsMap.map((m) => PlaylistTrackMapper.parse(m));
+  Pages<PlaylistTrack> playlistTracks(String userId, String playlistId) {
+    return _getPages(
+        '$_path/$userId/playlists/$playlistId/tracks',
+        PlaylistTrackMapper.parse
+    );
   }
 }

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2017, rinukkusu. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+part of spotify;
+
+typedef T ParserFunction<T>(Map<String, dynamic> object);
+
+@JsonClass()
+class Paging<T> {
+  /// A link to the Web API endpoint returning the full result of the request.
+  String href;
+
+  /// The requested data
+  ///
+  /// Note this is the raw JSON value. Use a [Page]'s [Page.items] to get the
+  /// requested data as a deserialized list.
+  @JsonField(key: 'items', native: true)
+  Iterable<Map> itemsNative;
+
+  /// The maximum number of items in the response (as set in the query or by
+  /// default).
+  int limit;
+
+  /// URL to the next page of items. ([null] if none)
+  String next;
+
+  /// The offset of the items returned (as set in the query or by default).
+  int offset;
+
+  /// URL to the previous page of items. (null if none)
+  String previous;
+
+  /// The total number of items available to return.
+  int total;
+}

--- a/lib/src/models/playlist.dart
+++ b/lib/src/models/playlist.dart
@@ -117,6 +117,12 @@ class PlaylistSimple {
 }
 
 @JsonClass()
+class PlaylistsFeatured {
+  /// The message of the day for Spotify's featured playlists
+  String message;
+}
+
+@JsonClass()
 class PlaylistTrack {
 
   /// The date and time the track was added.


### PR DESCRIPTION
I need to be able to get all pages of playlists for my application, so this adds generic pagination support to the library.

[`handlePageAndGetNext`](https://github.com/rinukkusu/spotify-dart/commit/102e890403eb1710343a6715c3eef2fef2e7d1f6#diff-d822f7be4e95853c3b06041b33b74074R79) for streaming pages feels kinda hacky to me.

I'd appreciate your input about how the paging API should work. :smile: