### PR TITLE
Add Search Endpoint.

### DIFF
--- a/example/spotify_dart_example.dart
+++ b/example/spotify_dart_example.dart
@@ -32,5 +32,23 @@ main() async {
     print(playlist.name);
   });
 
+  print("\nSearching for \'Metallica\':");
+  var search = await spotify.search.get("metallica", SearchType.all).firsts();
+  search.forEach((pages) {
+    pages.items.forEach((item) {
+      if (item is PlaylistSimple) {
+        print("Playlist: ${item.name}");
+      }
+      if (item is ArtistSimple) {
+        print("Artist ${item.name}");
+      }
+      if (item is Track) {
+        print("Track ${item.name}");
+      }
+      if (item is Album) {
+        print("Album ${item.name}");
+      }
+    });
+  });
   exit(0);
 }

--- a/lib/spotify_browser.dart
+++ b/lib/spotify_browser.dart
@@ -31,6 +31,7 @@ part 'src/endpoints/albums.dart';
 part 'src/endpoints/tracks.dart';
 part 'src/endpoints/playlists.dart';
 part 'src/endpoints/users.dart';
+part 'src/endpoints/search.dart';
 part 'src/endpoints/audio_features.dart';
 
 part 'src/spotify_credentials.dart';

--- a/lib/spotify_io.dart
+++ b/lib/spotify_io.dart
@@ -34,6 +34,7 @@ part 'src/endpoints/tracks.dart';
 part 'src/endpoints/playlists.dart';
 part 'src/endpoints/users.dart';
 part 'src/endpoints/audio_features.dart';
+part 'src/endpoints/search.dart';
 
 part 'src/spotify_credentials.dart';
 

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2017, chances. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+part of spotify;
+
+class Search extends EndpointPaging {
+  @override
+  String get _path => 'v1/search';
+
+  Search(SpotifyApiBase api) : super(api);
+
+   Pages<Object> get(String searchQuery, [SearchType searchType = SearchType.all]){
+     return _getBundledPages(
+         '$_path?q=$searchQuery&type=${searchType.key}', {
+           'playlists': (json) => PlaylistSimple.fromJson(json),
+           'albums': (json) => Album.fromJson(json),
+           'artists': (json) => ArtistSimple.fromJson(json),
+           'tracks': (json) => Track.fromJson(json)
+         }
+     );
+   }
+
+  Pages<PlaylistSimple> get me {
+     return _getPages('v1/me/playlists', (json) => Playlist.fromJson(json));
+  }
+}
+
+
+class SearchType {
+
+  final String _key;
+
+  const SearchType(this._key);
+  get key => _key;
+
+  static const all = SearchType("album,artist,playlist,track");
+  static const album = SearchType("album");
+  static const artist = SearchType("artist");
+  static const playlist = SearchType("playlist");
+  static const track = SearchType("track");
+}

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -16,6 +16,7 @@ abstract class SpotifyApiBase {
   Tracks _tracks;
   Playlists _playlists;
   Users _users;
+  Search _search;
   AudioFeatures _audioFeatures;
 
   Artists get artists => _artists;
@@ -23,6 +24,7 @@ abstract class SpotifyApiBase {
   Tracks get tracks => _tracks;
   Playlists get playlists => _playlists;
   Users get users => _users;
+  Search get search => _search;
   AudioFeatures get audioFeatures => _audioFeatures;
 
   SpotifyApiBase(this._credentials) {
@@ -31,6 +33,7 @@ abstract class SpotifyApiBase {
     _tracks = new Tracks(this);
     _playlists = new Playlists(this);
     _users = new Users(this);
+    _search = new Search(this);
     _audioFeatures = new AudioFeatures(this);
   }
 


### PR DESCRIPTION
This is a first attempt to add a search endpoint into this library. This is not a final stage, rather a discussion about the approach and maybe how it can be improved. Basically, this is the solution I came up with by giving the `Pages` class a `Map` of `ParserFunction`s (instead of only one) to enable distinguishing the different paging json objects in the search result. 