### PR TITLE
add APIToken setter method to support implicit grant functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pubspec.lock
 doc/api/
 
 .apikeys
+.idea/

--- a/lib/src/endpoints/artists.dart
+++ b/lib/src/endpoints/artists.dart
@@ -16,6 +16,26 @@ class Artists extends EndpointBase {
     return Artist.fromJson(map);
   }
 
+  Future<Iterable<Track>> getTopTracks(
+      String artistId, String countryCode) async {
+    var jsonString =
+        await _api._get('$_path/$artistId/top-tracks?country=$countryCode');
+    var map = json.decode(jsonString);
+
+    var topTracks = map['tracks'] as Iterable<dynamic>;
+    return topTracks.map((m) => Track.fromJson(m));
+  }
+
+  Future<Iterable<Artist>> getRelatedArtists(
+      String artistId) async {
+    var jsonString =
+        await _api._get('$_path/$artistId/related-artists');
+    var map = json.decode(jsonString);
+
+    var relatedArtists = map['artists'] as Iterable<dynamic>;
+    return relatedArtists.map((m) => Artist.fromJson(m));
+  }
+
   Future<Iterable<Artist>> list(Iterable<String> artistIds) async {
     var jsonString = await _api._get('$_path?ids=${artistIds.join(',')}');
     var map = json.decode(jsonString);

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -18,9 +18,29 @@ class Users extends EndpointPaging {
 
   Future<Player> currentlyPlaying() async {
     var jsonString = await _api._get('v1/me/player/currently-playing');
+
+    if (jsonString.isEmpty) {
+      return new Player();
+    }
+
+    var map = json.decode(jsonString);
+    return Player.fromJson(map);
+  }
+
+  Future<Iterable<Track>> recentlyPlayed() async {
+    var jsonString = await _api._get('v1/me/player/recently-played');
     var map = json.decode(jsonString);
 
-    return Player.fromJson(map);
+    var items = map["items"] as Iterable<dynamic>;
+    return items.map((item) => Track.fromJson(item["track"]));
+  }
+
+  Future<Iterable<Track>> topTracks() async {
+    var jsonString = await _api._get('v1/me/top/tracks');
+    var map = json.decode(jsonString);
+
+    var items = map["items"] as Iterable<dynamic>;
+    return items.map((item) => Track.fromJson(item));
   }
 
   Future<UserPublic> get(String userId) async {

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -5,7 +5,10 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Player extends Object {
-  Player() {}
+  Player() {
+    is_playing = false;
+  }
+
   factory Player.fromJson(Map<String, dynamic> json) => _$PlayerFromJson(json);
 
   /// Unix Millisecond Timestamp when data was fetched
@@ -31,6 +34,7 @@ class Player extends Object {
 @JsonSerializable(createToJson: false)
 class PlayerContext extends Object {
   PlayerContext() {}
+
   factory PlayerContext.fromJson(Map<String, dynamic> json) =>
       _$PlayerContextFromJson(json);
 
@@ -46,4 +50,3 @@ class PlayerContext extends Object {
   /// The uri of the context.
   String uri;
 }
-

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -20,12 +20,21 @@ abstract class SpotifyApiBase {
   AudioFeatures _audioFeatures;
 
   Artists get artists => _artists;
+
   Albums get albums => _albums;
+
   Tracks get tracks => _tracks;
+
   Playlists get playlists => _playlists;
+
   Users get users => _users;
+
   Search get search => _search;
+
   AudioFeatures get audioFeatures => _audioFeatures;
+
+  set apiToken(Map<String, dynamic> tokenJson) =>
+      {_apiToken = ApiToken.fromJson(tokenJson)};
 
   SpotifyApiBase(this._credentials) {
     _artists = new Artists(this);
@@ -73,8 +82,10 @@ abstract class SpotifyApiBase {
   }
 
   Future<String> _getImpl(String url, Map<String, String> headers);
+
   Future<String> _postImpl(
       String url, Map<String, String> headers, dynamic body);
+
   Future<String> _putImpl(
       String url, Map<String, String> headers, dynamic body);
 }


### PR DESCRIPTION
For implicit grant authorization you need to do it by directing the user to the webpage. After they log in you can obtain the access token but currently `spotify-dart` doesn't have a way to set this token. opening up the token to be explicitly set, lets us use a lot of endpoints that are specific to individual user spotify data like the /me endpoint. 

what's also kind of cool about this is when the implicit grant token expires the refresh token method will be called and then we still have client_credentials permissions. 

