### PR TITLE
Added refresh token support and improved users.recentlyPlayed() (fixes #30)

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -99,5 +99,27 @@ main() async {
 
   var relatedArtists = await spotify.artists.relatedArtists('0OdUWJ0sBjDrqHygGUXeCF');
   print('related Artists: ${relatedArtists.length}');
+
+  print('\nRefresh Token:');
+  credentials = new SpotifyApiCredentials(keyMap['id'], keyMap['secret'], keyMap['refreshToken'] ?? null);
+  spotify = new SpotifyApi(credentials);
+  var recent = await spotify.users.recentlyPlayed(limit: 5);
+  recent.forEach((history) {
+    print('Played At: ${history.playedAt}\n'
+        'Track:\n'
+        'id: ${history.track.id}\n'
+        'name: ${history.track.name}\n'
+        'href: ${history.track.href}\n'
+        'type: ${history.track.type}\n'
+        'uri: ${history.track.uri}\n'
+        'isPlayable: ${history.track.isPlayable}\n'
+        'artists: ${history.track.artists.length}\n'
+        'availableMarkets: ${history.track.availableMarkets.length}\n'
+        'discNumber: ${history.track.discNumber}\n'
+        'trackNumber: ${history.track.trackNumber}\n'
+        'explicit: ${history.track.explicit}\n'
+        '-------------------------------');
+  });
+
   exit(0);
 }

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -142,7 +142,7 @@ class Pages<T> extends _Pages<Page<T>> {
       var paging = Paging<T>.fromJson(map);
       return Page<T>(paging, _pageParser);
     } else {
-      var paging = Paging.fromJson(map[_pageKey]);
+      var paging = Paging<T>.fromJson(map[_pageKey]);
       var container = _pageContainerParser(map);
       return new Page(paging, _pageParser, container);
     }

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -27,12 +27,30 @@ class Users extends EndpointPaging {
     return Player.fromJson(map);
   }
 
-  Future<Iterable<Track>> recentlyPlayed() async {
-    var jsonString = await _api._get('v1/me/player/recently-played');
+  Future<Iterable<PlayHistory>> recentlyPlayed({int limit, DateTime after, DateTime before}) async {
+    if (after != null && before != null) {
+      throw new Exception('Cannot specify both after and before.');
+    }
+
+    var queryParams = [];
+
+    if (limit != null) {
+      queryParams.add('limit=$limit');
+    }
+
+    if (after != null) {
+      queryParams.add('after=${after.millisecondsSinceEpoch}');
+    }
+
+    if (before != null) {
+      queryParams.add('before=${before.millisecondsSinceEpoch}');
+    }
+
+    var jsonString = await _api._get('v1/me/player/recently-played?' + queryParams.join('&'));
     var map = json.decode(jsonString);
 
     var items = map["items"] as Iterable<dynamic>;
-    return items.map((item) => Track.fromJson(item["track"]));
+    return items.map((item) => PlayHistory.fromJson(item));
   }
 
   Future<Iterable<Track>> topTracks() async {

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -158,9 +158,7 @@ Image _$ImageFromJson(Map<String, dynamic> json) {
 Paging<T> _$PagingFromJson<T>(Map<String, dynamic> json) {
   return Paging<T>()
     ..href = json['href'] as String
-    ..itemsNative = json['items'] == null
-        ? null
-        : itemsNativeFromJson(json['items'] as List)
+    ..itemsNative = itemsNativeFromJson(json['items'] as List)
     ..limit = json['limit'] as int
     ..next = json['next'] as String
     ..offset = json['offset'] as int
@@ -387,6 +385,16 @@ UserPublic _$UserPublicFromJson(Map<String, dynamic> json) {
         ?.toList()
     ..type = json['type'] as String
     ..uri = json['uri'] as String;
+}
+
+PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) {
+  return PlayHistory()
+    ..track = json['track'] == null
+        ? null
+        : TrackSimple.fromJson(json['track'] as Map<String, dynamic>)
+    ..playedAt = json['played_at'] == null
+        ? null
+        : DateTime.parse(json['played_at'] as String);
 }
 
 Category _$CategoryFromJson(Map<String, dynamic> json) {

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -95,3 +95,17 @@ class UserPublic extends Object {
   /// The Spotify URI for this user.
   String uri;
 }
+
+@JsonSerializable(createToJson: false)
+class PlayHistory extends Object {
+  PlayHistory() {}
+  factory PlayHistory.fromJson(Map<String, dynamic> json) =>
+      _$PlayHistoryFromJson(json);
+
+  /// The track that was played.
+  TrackSimple track;
+
+  /// When the track was played.
+  @JsonKey(name: 'played_at')
+  DateTime playedAt;
+}

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -52,7 +52,15 @@ abstract class SpotifyApiBase {
   Future<Null> _refreshToken() async {
     if (_apiToken == null || _apiToken.isExpired) {
       var headers = {'Authorization': 'Basic ${_credentials.basicAuth}'};
-      var body = {'grant_type': 'client_credentials'};
+      var body;
+
+      if (_credentials.hasRefreshToken) {
+        body = {'grant_type': 'refresh_token', 'refresh_token': _credentials.refreshToken};
+      }
+
+      else {
+        body = {'grant_type': 'client_credentials'};
+      }
 
       var responseJson = await _postImpl(_tokenRefreshUrl, headers, body);
       var responseMap = json.decode(responseJson);

--- a/lib/src/spotify_credentials.dart
+++ b/lib/src/spotify_credentials.dart
@@ -6,8 +6,11 @@ part of spotify;
 class SpotifyApiCredentials {
   final String clientId;
   final String clientSecret;
+  final String refreshToken;
 
-  SpotifyApiCredentials(this.clientId, this.clientSecret);
+  SpotifyApiCredentials(this.clientId, this.clientSecret, [this.refreshToken = null]);
 
   String get basicAuth => base64.encode('$clientId:$clientSecret'.codeUnits);
+
+  bool get hasRefreshToken => refreshToken != null;
 }


### PR DESCRIPTION
This commit adds the ability for the user to specify a refresh token to `SpotifyApiCredentials`. If a refresh token is specified, it is used by `_refreshToken()`.

This commit also improves the `users.recentlyPlayed()` function to allow for specifying the query parameters `limit`, `after`, and `before`, and it now returns a `Future<Iterable<PlayHistory>>` which captures the `played_at` timestamp in addition to the track.