### PR TITLE
Improve static analysis health

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:pedantic/analysis_options.yaml
+
 analyzer:
 #   exclude:
 #     - path/to/excluded/files/**

--- a/example/example.dart
+++ b/example/example.dart
@@ -3,9 +3,9 @@
 
 import 'dart:io';
 import 'dart:convert';
-import '../lib/spotify_io.dart';
+import 'package:spotify/spotify_io.dart';
 
-main() async {
+void main() async {
   var keyJson = await File('example/.apikeys').readAsString();
   var keyMap = json.decode(keyJson);
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -6,27 +6,27 @@ import 'dart:convert';
 import '../lib/spotify_io.dart';
 
 main() async {
-  var keyJson = await new File('example/.apikeys').readAsString();
+  var keyJson = await File('example/.apikeys').readAsString();
   var keyMap = json.decode(keyJson);
 
-  var credentials = new SpotifyApiCredentials(keyMap['id'], keyMap['secret']);
+  var credentials = SpotifyApiCredentials(keyMap['id'], keyMap['secret']);
   var spotify = SpotifyApi(credentials);
 
-  print("Artists:");
+  print('Artists:');
   var artists = await spotify.artists.list(['0OdUWJ0sBjDrqHygGUXeCF']);
   artists.forEach((x) => print(x.name));
 
-  print("\nAlbum:");
+  print('\nAlbum:');
   var album = await spotify.albums.get('2Hog1V8mdTWKhCYqI5paph');
   print(album.name);
 
-  print("\nAlbum Tracks:");
+  print('\nAlbum Tracks:');
   var tracks = await spotify.albums.getTracks(album.id).all();
   tracks.forEach((track) {
     print(track.name);
   });
 
-  print("\nFeatured Playlist:");
+  print('\nFeatured Playlist:');
   var featuredPlaylists = await spotify.playlists.featured.all();
   featuredPlaylists.forEach((playlist) {
     print(playlist.name);
@@ -34,7 +34,7 @@ main() async {
 
   print("\nSearching for \'Metallica\':");
   var search = await spotify.search
-      .get("metallica")
+      .get('metallica')
       .first(2)
       .catchError((err) => print((err as SpotifyException).message));
   if (search == null) {
@@ -97,7 +97,8 @@ main() async {
     });
   });
 
-  var relatedArtists = await spotify.artists.relatedArtists('0OdUWJ0sBjDrqHygGUXeCF');
+  var relatedArtists =
+      await spotify.artists.relatedArtists('0OdUWJ0sBjDrqHygGUXeCF');
   print('related Artists: ${relatedArtists.length}');
   exit(0);
 }

--- a/lib/src/endpoints/artists.dart
+++ b/lib/src/endpoints/artists.dart
@@ -26,10 +26,8 @@ class Artists extends EndpointBase {
     return topTracks.map((m) => Track.fromJson(m));
   }
 
-  Future<Iterable<Artist>> getRelatedArtists(
-      String artistId) async {
-    var jsonString =
-        await _api._get('$_path/$artistId/related-artists');
+  Future<Iterable<Artist>> getRelatedArtists(String artistId) async {
+    var jsonString = await _api._get('$_path/$artistId/related-artists');
     var map = json.decode(jsonString);
 
     var relatedArtists = map['artists'] as Iterable<dynamic>;

--- a/lib/src/endpoints/categories.dart
+++ b/lib/src/endpoints/categories.dart
@@ -22,7 +22,7 @@ class Categories extends EndpointPaging {
   /// country=SE&locale=de_DE will return a list of categories relevant to
   /// Sweden but as German language strings.
   Pages<Category> list({String country, String locale}) {
-    final String query = _buildQuery({'country': country, 'locale': locale});
+    final query = _buildQuery({'country': country, 'locale': locale});
 
     return _getPages(
       '$_path?$query',
@@ -46,7 +46,7 @@ class Categories extends EndpointPaging {
   /// [categoryId] - the Spotify category ID for the category.
   Future<Category> get(String categoryId,
       {String country, String locale}) async {
-    final String query = _buildQuery({'country': country, 'locale': locale});
+    final query = _buildQuery({'country': country, 'locale': locale});
 
     var jsonString = await _api._get('$_path/$categoryId?$query');
     var map = json.decode(jsonString);

--- a/lib/src/endpoints/endpoint_base.dart
+++ b/lib/src/endpoints/endpoint_base.dart
@@ -4,12 +4,16 @@
 part of spotify;
 
 abstract class EndpointBase {
+  // ignore: unused_element
   String get _path;
+
   final SpotifyApiBase _api;
 
   EndpointBase(this._api);
 
   Future<String> _get(String path) => _api._get(path);
+
+  // ignore: unused_element
   Future<String> _post(String path, String body) => _api._post(path, body);
 
   String _buildQuery(Map<String, dynamic> query) {

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -161,7 +161,7 @@ class BundledPages extends _Pages<List<Page<Object>>> {
 
   List<Page<Object>> _parseBundledPage(String jsonString) {
     var map = json.decode(jsonString);
-    var pages = [];
+    var pages = <Page<Object>>[];
     _pageMappers.forEach((key, value) {
       if (map[key] != null) {
         var paging = Paging.fromJson(map[key]);

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -7,25 +7,21 @@ abstract class EndpointPaging extends EndpointBase {
   EndpointPaging(SpotifyApiBase api) : super(api);
 
   Pages<T> _getPages<T>(String path, ParserFunction<T> pageItemParser,
-          [String pageKey = null,
-          ParserFunction<Object> pageContainerParser = null]) =>
-      new Pages(_api, path, pageItemParser, pageKey, pageContainerParser);
+          [String pageKey, ParserFunction<Object> pageContainerParser]) =>
+      Pages(_api, path, pageItemParser, pageKey, pageContainerParser);
 
   BundledPages _getBundledPages<T>(
           String path, Map<String, ParserFunction<T>> pageItemParsers,
-          [String pageKey = null,
-          ParserFunction<Object> pageContainerParser = null]) =>
-      new BundledPages(
-          _api, path, pageItemParsers, pageKey, pageContainerParser);
+          [String pageKey, ParserFunction<Object> pageContainerParser]) =>
+      BundledPages(_api, path, pageItemParsers, pageKey, pageContainerParser);
 }
 
 class Page<T> {
-  Paging<T> _paging;
+  final Paging<T> _paging;
   Iterable<T> _items;
   Object _container;
 
-  Page(this._paging, ParserFunction<T> pageItemParser,
-      [Object pageContainer = null]) {
+  Page(this._paging, ParserFunction<T> pageItemParser, [Object pageContainer]) {
     _items = _paging.itemsNative.map(pageItemParser);
     _container = pageContainer;
   }
@@ -49,17 +45,16 @@ class Page<T> {
 const defaultLimit = 20;
 
 abstract class _Pages<T> {
-  SpotifyApiBase _api;
-  String _path;
-  String _pageKey;
-  ParserFunction<Object> _pageContainerParser;
+  final SpotifyApiBase _api;
+  final String _path;
+  final String _pageKey;
+  final ParserFunction<Object> _pageContainerParser;
 
-  _Pages(this._api, this._path,
-      [this._pageKey = null, this._pageContainerParser = null]) {
+  _Pages(this._api, this._path, [this._pageKey, this._pageContainerParser]) {
     if (_pageKey != null && _pageContainerParser == null) {
-      throw new ArgumentError.notNull('pageContainerParser');
+      throw ArgumentError.notNull('pageContainerParser');
     } else if (_pageKey == null && _pageContainerParser != null) {
-      throw new ArgumentError.notNull('pageKey');
+      throw ArgumentError.notNull('pageKey');
     }
   }
 
@@ -72,13 +67,12 @@ abstract class _Pages<T> {
 }
 
 class Pages<T> extends _Pages<Page<T>> {
-  ParserFunction<T> _pageParser;
-  List<Page<T>> _bufferedPages = [];
+  final ParserFunction<T> _pageParser;
+  final List<Page<T>> _bufferedPages = [];
   bool _cancelled = false;
 
   Pages(SpotifyApi api, String path, this._pageParser,
-      [String pageKey = null,
-      ParserFunction<Object> pageContainerMapper = null])
+      [String pageKey, ParserFunction<Object> pageContainerMapper])
       : super(api, path, pageKey, pageContainerMapper);
 
   Future<Iterable<T>> all([int limit = defaultLimit]) {
@@ -115,12 +109,12 @@ class Pages<T> extends _Pages<Page<T>> {
       getPage(limit, page.nextOffset).then(handlePageAndGetNext);
     }
 
-    stream = new StreamController<Page<T>>(onListen: () {
+    stream = StreamController<Page<T>>(onListen: () {
       var firstPage = first(limit);
       firstPage.then(handlePageAndGetNext);
     }, onCancel: () {
       _cancelled = true;
-      return new Future.value(true);
+      return Future.value(true);
     }, onResume: () {
       _bufferedPages.forEach(stream.add);
       if (_bufferedPages.last.isLast) {
@@ -131,6 +125,7 @@ class Pages<T> extends _Pages<Page<T>> {
     return stream.stream;
   }
 
+  @override
   Future<Page<T>> getPage(int limit, int offset) async {
     var pathDelimiter = _path.contains('?') ? '&' : '?';
     var newPath = '$_path${pathDelimiter}limit=$limit&offset=$offset';
@@ -144,18 +139,19 @@ class Pages<T> extends _Pages<Page<T>> {
     } else {
       var paging = Paging<T>.fromJson(map[_pageKey]);
       var container = _pageContainerParser(map);
-      return new Page<T>(paging, _pageParser, container);
+      return Page<T>(paging, _pageParser, container);
     }
   }
 }
 
 class BundledPages extends _Pages<List<Page<Object>>> {
-  Map<String, ParserFunction<Object>> _pageMappers;
+  final Map<String, ParserFunction<Object>> _pageMappers;
 
   BundledPages(SpotifyApiBase api, String path, this._pageMappers,
       [String pageKey, ParserFunction<Object> pageContainerParser])
       : super(api, path, pageKey, pageContainerParser);
 
+  @override
   Future<List<Page<Object>>> getPage(int limit, int offset) async {
     var pathDelimiter = _path.contains('?') ? '&' : '?';
     var path = '$_path${pathDelimiter}limit=$limit&offset=$offset';
@@ -165,16 +161,16 @@ class BundledPages extends _Pages<List<Page<Object>>> {
 
   List<Page<Object>> _parseBundledPage(String jsonString) {
     var map = json.decode(jsonString);
-    List<Page<Object>> pages = [];
+    var pages = [];
     _pageMappers.forEach((key, value) {
       if (map[key] != null) {
         var paging = Paging.fromJson(map[key]);
         var page;
         if (_pageContainerParser == null) {
-          page = new Page(paging, value);
+          page = Page(paging, value);
         } else {
           var container = _pageContainerParser(map[key]);
-          page = new Page(paging, value, container);
+          page = Page(paging, value, container);
         }
         pages.add(page);
       }

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -18,7 +18,8 @@ class Playlists extends EndpointPaging {
   }
 
   Pages<PlaylistSimple> get me {
-    return _getPages('v1/me/playlists', (json) => PlaylistSimple.fromJson(json));
+    return _getPages(
+        'v1/me/playlists', (json) => PlaylistSimple.fromJson(json));
   }
 
   /// [playlistId] - the Spotify playlist ID
@@ -31,9 +32,9 @@ class Playlists extends EndpointPaging {
   ///
   /// [playlistName] - the name of the new playlist
   Future<Playlist> createPlaylist(String userId, String playlistName) async {
-    final url = "v1/users/$userId/playlists";
+    final url = 'v1/users/$userId/playlists';
     final playlistJson =
-        await _api._post(url, jsonEncode({"name": playlistName}));
+        await _api._post(url, jsonEncode({'name': playlistName}));
     return await Playlist.fromJson(jsonDecode(playlistJson));
   }
 
@@ -41,7 +42,7 @@ class Playlists extends EndpointPaging {
   ///
   /// [playlistId] - the playlist ID
   Future<Null> addTrack(String trackUri, String playlistId) async {
-    final url = "v1/playlists/$playlistId/tracks";
+    final url = 'v1/playlists/$playlistId/tracks';
     await _api._post(
         url,
         jsonEncode({
@@ -49,12 +50,17 @@ class Playlists extends EndpointPaging {
         }));
   }
 
-  Future<Null> removeTrack(String trackUri, String playlistId, [List<int> positions]) async {
-    final url = "v1/playlists/$playlistId/tracks";
-    final track = <String, dynamic>{"uri": trackUri};
-    if (positions != null)
+  Future<Null> removeTrack(String trackUri, String playlistId,
+      [List<int> positions]) async {
+    final url = 'v1/playlists/$playlistId/tracks';
+    final track = <String, dynamic>{'uri': trackUri};
+    if (positions != null) {
       track['positions'] = positions;
-    final body = jsonEncode({"tracks":[track]});
+    }
+
+    final body = jsonEncode({
+      'tracks': [track]
+    });
     await _api._delete(url, body);
   }
 
@@ -72,7 +78,7 @@ class Playlists extends EndpointPaging {
   /// [categoryId] - the Spotify category ID for the category.
   Pages<PlaylistSimple> getByCategoryId(String categoryId,
       {String country, String locale}) {
-    final String query = _buildQuery({'country': country, 'locale': locale});
+    final query = _buildQuery({'country': country, 'locale': locale});
 
     return _getPages(
         '$_path/categories/$categoryId/playlists?$query',

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -11,7 +11,7 @@ class Search extends EndpointPaging {
 
   BundledPages get(String searchQuery,
       [Iterable<SearchType> types = SearchType.all]) {
-    var type = types.map((type) => type.key).join(",");
+    var type = types.map((type) => type.key).join(',');
     return _getBundledPages('$_path?q=$searchQuery&type=${type}', {
       'playlists': (json) => PlaylistSimple.fromJson(json),
       'albums': (json) => AlbumSimple.fromJson(json),
@@ -25,12 +25,12 @@ class SearchType {
   final String _key;
 
   const SearchType(this._key);
-  get key => _key;
+  String get key => _key;
 
-  static const album = SearchType("album");
-  static const artist = SearchType("artist");
-  static const playlist = SearchType("playlist");
-  static const track = SearchType("track");
+  static const album = SearchType('album');
+  static const artist = SearchType('artist');
+  static const playlist = SearchType('playlist');
+  static const track = SearchType('track');
   static const all = [
     SearchType.album,
     SearchType.artist,

--- a/lib/src/endpoints/tracks.dart
+++ b/lib/src/endpoints/tracks.dart
@@ -9,7 +9,7 @@ class Tracks extends EndpointBase {
   String get _path => 'v1/tracks';
 
   Tracks(SpotifyApiBase api) : super(api) {
-    _me = new TracksMe(api);
+    _me = TracksMe(api);
   }
 
   TracksMe get me => _me;
@@ -46,8 +46,8 @@ class TracksMe extends EndpointPaging {
   }
 
   Future<List<bool>> contains(List<String> ids) async {
-    int limit = ids.length < 50 ? ids.length : 50;
-    String idsParam = ids.sublist(0, limit).join(',');
+    var limit = ids.length < 50 ? ids.length : 50;
+    var idsParam = ids.sublist(0, limit).join(',');
     var jsonString = await _api._get('$_path/contains?ids=$idsParam');
     List<bool> list = json.decode(jsonString);
     return list;
@@ -58,8 +58,8 @@ class TracksMe extends EndpointPaging {
   }
 
   Future<Null> save(List<String> ids) async {
-    int limit = ids.length < 50 ? ids.length : 50;
-    String idsParam = ids.sublist(0, limit).join(',');
+    var limit = ids.length < 50 ? ids.length : 50;
+    var idsParam = ids.sublist(0, limit).join(',');
     await _api._put('$_path?ids=$idsParam', '');
   }
 }

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -20,7 +20,7 @@ class Users extends EndpointPaging {
     var jsonString = await _api._get('v1/me/player/currently-playing');
 
     if (jsonString.isEmpty) {
-      return new Player();
+      return Player();
     }
 
     var map = json.decode(jsonString);
@@ -31,15 +31,15 @@ class Users extends EndpointPaging {
     var jsonString = await _api._get('v1/me/player/recently-played');
     var map = json.decode(jsonString);
 
-    var items = map["items"] as Iterable<dynamic>;
-    return items.map((item) => Track.fromJson(item["track"]));
+    var items = map['items'] as Iterable<dynamic>;
+    return items.map((item) => Track.fromJson(item['track']));
   }
 
   Future<Iterable<Track>> topTracks() async {
     var jsonString = await _api._get('v1/me/top/tracks');
     var map = json.decode(jsonString);
 
-    var items = map["items"] as Iterable<dynamic>;
+    var items = map['items'] as Iterable<dynamic>;
     return items.map((item) => Track.fromJson(item));
   }
 

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -158,9 +158,7 @@ Image _$ImageFromJson(Map<String, dynamic> json) {
 Paging<T> _$PagingFromJson<T>(Map<String, dynamic> json) {
   return Paging<T>()
     ..href = json['href'] as String
-    ..itemsNative = json['items'] == null
-        ? null
-        : itemsNativeFromJson(json['items'] as List)
+    ..itemsNative = itemsNativeFromJson(json['items'] as List)
     ..limit = json['limit'] as int
     ..next = json['next'] as String
     ..offset = json['offset'] as int

--- a/lib/src/models/album.dart
+++ b/lib/src/models/album.dart
@@ -5,7 +5,8 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Album extends AlbumSimple {
-  Album() {}
+  Album();
+
   factory Album.fromJson(Map<String, dynamic> json) => _$AlbumFromJson(json);
 
   /// The copyright statements of the album.
@@ -15,44 +16,37 @@ class Album extends AlbumSimple {
   @JsonKey(name: 'external_ids')
   ExternalIds externalIds;
 
-  /**
-   * A list of the genres the artist is associated with. 
-   * For example: 
-   *     "Prog Rock", "Post-Grunge". 
-   * 
-   * (If not yet classified, the array is empty.) 
-   */
+  /// A list of the genres the artist is associated with.
+  /// For example:
+  ///     "Prog Rock", "Post-Grunge".
+  ///
+  /// (If not yet classified, the array is empty.)
   List<String> genres;
 
   /// The label for the album.
   String label;
 
-  /**
-   * The popularity of the artist. The value will be between 0 and 100, with 100
-   * being the most popular. The artist's popularity is calculated from the 
-   * popularity of all the artist's tracks.
-   */
+  /// The popularity of the artist. The value will be between 0 and 100, with 100
+  /// being the most popular. The artist's popularity is calculated from the
+  /// popularity of all the artist's tracks.
   int popularity;
 
-  /**
-   * The date the album was first released, for example "1981-12-15". 
-   * Depending on the precision, it might be shown as "1981" or "1981-12".
-   */
+  /// The date the album was first released, for example "1981-12-15".
+  /// Depending on the precision, it might be shown as "1981" or "1981-12".
   @JsonKey(name: 'release_date')
   String releaseDate;
 
-  /**
-   * The precision with which release_date value is known: 
-   *     "year", "month", or "day".
-   */
+  /// The precision with which release_date value is known:
+  ///     "year", "month", or "day".
   @JsonKey(name: 'release_date_precision')
   String releaseDatePrecision;
 }
 
 @JsonSerializable(createToJson: false)
 class AlbumSimple extends Object {
-  AlbumSimple() {}
-  factory AlbumSimple.fromJson(Map<String, dynamic> json) => 
+  AlbumSimple();
+
+  factory AlbumSimple.fromJson(Map<String, dynamic> json) =>
       // sometimes a richer version than AlbumSimple is returned - trying to catch that here
       json.containsKey('release_date')
           ? _$AlbumFromJson(json)
@@ -62,17 +56,13 @@ class AlbumSimple extends Object {
   @JsonKey(name: 'album_type')
   String albumType;
 
-  /**
-   * The artists of the album. Each artist object includes a link in href to 
-   * more detailed information about the artist.
-   */
+  /// The artists of the album. Each artist object includes a link in href to
+  /// more detailed information about the artist.
   List<ArtistSimple> artists;
 
-  /**
-   * The markets in which the album is available: ISO 3166-1 alpha-2 country 
-   * codes. Note that an album is considered available in a market when at least
-   * 1 of its tracks is available in that market.
-   */
+  /// The markets in which the album is available: ISO 3166-1 alpha-2 country
+  /// codes. Note that an album is considered available in a market when at least
+  /// 1 of its tracks is available in that market.
   @JsonKey(name: 'available_markets')
   List<String> availableMarkets;
 
@@ -89,10 +79,8 @@ class AlbumSimple extends Object {
   /// The cover art for the album in various sizes, widest first.
   List<Image> images;
 
-  /**
-   * The name of the album. In case of an album takedown, the value may be an 
-   * empty string.
-   */
+  /// The name of the album. In case of an album takedown, the value may be an
+  /// empty string.
   String name;
 
   /// The object type: "album"
@@ -104,7 +92,7 @@ class AlbumSimple extends Object {
 
 @JsonSerializable(createToJson: false)
 class Copyright extends Object {
-  Copyright() {}
+  Copyright();
   factory Copyright.fromJson(Map<String, dynamic> json) =>
       _$CopyrightFromJson(json);
 

--- a/lib/src/models/artist.dart
+++ b/lib/src/models/artist.dart
@@ -5,54 +5,58 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Artist extends Object implements ArtistSimple {
-  Artist() {}
+  Artist();
+
   factory Artist.fromJson(Map<String, dynamic> json) => _$ArtistFromJson(json);
 
   /// Known external URLs for this artist.
   @JsonKey(name: 'external_urls')
+  @override
   ExternalUrls externalUrls;
 
   /// A link to the Web API endpoint providing full details of the artist.
+  @override
   String href;
 
   /// The Spotify ID for the artist.
+  @override
   String id;
 
   /// The name of the artist
+  @override
   String name;
 
   /// The object type: "artist"
+  @override
   String type;
 
   /// The Spotify URI for the artist.
+  @override
   String uri;
 
   /// Information about the followers of the artist.
   Followers followers;
 
-  /**
-   * A list of the genres the artist is associated with. 
-   * For example: 
-   *    "Prog Rock", "Post-Grunge". 
-   * 
-   * (If not yet classified, the array is empty.) 
-   */
+  /// A list of the genres the artist is associated with.
+  /// For example:
+  ///    "Prog Rock", "Post-Grunge".
+  ///
+  /// (If not yet classified, the array is empty.)
   List<String> genres;
 
   /// Images of the artist in various sizes, widest first.
   List<Image> images;
 
-  /**
-   * The popularity of the artist. The value will be between 0 and 100, with 100
-   * being the most popular. The artist's popularity is calculated from the 
-   * popularity of all the artist's tracks.
-   */
+  /// The popularity of the artist. The value will be between 0 and 100, with 100
+  /// being the most popular. The artist's popularity is calculated from the
+  /// popularity of all the artist's tracks.
   int popularity;
 }
 
 @JsonSerializable(createToJson: false)
 class ArtistSimple extends Object {
-  ArtistSimple() {}
+  ArtistSimple();
+
   factory ArtistSimple.fromJson(Map<String, dynamic> json) =>
       _$ArtistSimpleFromJson(json);
 

--- a/lib/src/models/audio_feature.dart
+++ b/lib/src/models/audio_feature.dart
@@ -5,29 +5,24 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class AudioFeature extends Object {
-  AudioFeature() {}
+  AudioFeature();
+
   factory AudioFeature.fromJson(Map<String, dynamic> json) =>
       _$AudioFeatureFromJson(json);
 
-  /**
-   * A confidence measure from 0.0 to 1.0 of whether the track is acoustic. 
-   * 1.0 represents high confidence the track is acoustic.
-   */
+  /// A confidence measure from 0.0 to 1.0 of whether the track is acoustic.
+  /// 1.0 represents high confidence the track is acoustic.
   double acousticness;
 
-  /**
-   * An HTTP URL to access the full audio analysis of this track. An access 
-   * token is required to access this data.
-   */
+  /// An HTTP URL to access the full audio analysis of this track. An access
+  /// token is required to access this data.
   @JsonKey(name: 'analysis_url')
   String analysisUrl;
 
-  /**
-   * Danceability describes how suitable a track is for dancing based on a 
-   * combination of musical elements including tempo, rhythm stability, beat 
-   * strength, and overall regularity. A value of 0.0 is least danceable and 
-   * 1.0 is most danceable.
-   */
+  /// Danceability describes how suitable a track is for dancing based on a
+  /// combination of musical elements including tempo, rhythm stability, beat
+  /// strength, and overall regularity. A value of 0.0 is least danceable and
+  /// 1.0 is most danceable.
   double danceability;
 
   /// The track length in milliseconds.
@@ -36,83 +31,65 @@ class AudioFeature extends Object {
 
   /// The track length
   @JsonKey(ignore: true)
-  Duration get duration => new Duration(milliseconds: durationMs);
+  Duration get duration => Duration(milliseconds: durationMs);
 
-  /**
-   * Energy is a measure from 0.0 to 1.0 and represents a perceptual measure of
-   * intensity and activity. Typically, energetic tracks feel fast, loud, and 
-   * noisy. For example, death metal has high energy, while a Bach prelude 
-   * scores low on the scale. Perceptual features contributing to this 
-   * attribute include dynamic range, perceived loudness, timbre, onset rate, 
-   * and general entropy.
-   */
+  /// Energy is a measure from 0.0 to 1.0 and represents a perceptual measure of
+  /// intensity and activity. Typically, energetic tracks feel fast, loud, and
+  /// noisy. For example, death metal has high energy, while a Bach prelude
+  /// scores low on the scale. Perceptual features contributing to this
+  /// attribute include dynamic range, perceived loudness, timbre, onset rate,
+  /// and general entropy.
   double energy;
 
   /// The Spotify ID for the track.
   String id;
 
-  /**
-   * Predicts whether a track contains no vocals. "Ooh" and "aah" sounds are 
-   * treated as instrumental in this context. Rap or spoken word tracks are 
-   * clearly "vocal". The closer the instrumentalness value is to 1.0, the 
-   * greater likelihood the track contains no vocal content. Values above 0.5 
-   * are intended to represent instrumental tracks, but confidence is higher as
-   * the value approaches 1.0.
-   */
+  /// Predicts whether a track contains no vocals. "Ooh" and "aah" sounds are
+  /// treated as instrumental in this context. Rap or spoken word tracks are
+  /// clearly "vocal". The closer the instrumentalness value is to 1.0, the
+  /// greater likelihood the track contains no vocal content. Values above 0.5
+  /// are intended to represent instrumental tracks, but confidence is higher as
+  /// the value approaches 1.0.
   double instrumentalness;
 
-  /**
-   * The key the track is in. Integers map to pitches using standard Pitch 
-   * Class notation. E.g. 0 = C, 1 = C♯/D♭, 2 = D, and so on.
-   */
+  /// The key the track is in. Integers map to pitches using standard Pitch
+  /// Class notation. E.g. 0 = C, 1 = C♯/D♭, 2 = D, and so on.
   int key;
 
-  /**
-   * Detects the presence of an audience in the recording. Higher liveness 
-   * values represent an increased probability that the track was performed 
-   * live. A value above 0.8 provides strong likelihood that the track is live.
-   */
+  /// Detects the presence of an audience in the recording. Higher liveness
+  /// values represent an increased probability that the track was performed
+  /// live. A value above 0.8 provides strong likelihood that the track is live.
   double liveness;
 
-  /**
-   * The overall loudness of a track in decibels (dB). Loudness values are 
-   * averaged across the entire track and are useful for comparing relative 
-   * loudness of tracks. Loudness is the quality of a sound that is the primary
-   * psychological correlate of physical strength (amplitude). Values typical 
-   * range between -60 and 0 db.
-   */
+  /// The overall loudness of a track in decibels (dB). Loudness values are
+  /// averaged across the entire track and are useful for comparing relative
+  /// loudness of tracks. Loudness is the quality of a sound that is the primary
+  /// psychological correlate of physical strength (amplitude). Values typical
+  /// range between -60 and 0 db.
   double loudness;
 
-  /**
-   * Mode indicates the modality (major or minor) of a track, the type of scale
-   * from which its melodic content is derived. Major is represented by 1 and
-   * minor is 0.
-   */
+  /// Mode indicates the modality (major or minor) of a track, the type of scale
+  /// from which its melodic content is derived. Major is represented by 1 and
+  /// minor is 0.
   int mode;
 
-  /**
-   * Speechiness detects the presence of spoken words in a track. The more 
-   * exclusively speech-like the recording (e.g. talk show, audio book, poetry), 
-   * the closer to 1.0 the attribute value. Values above 0.66 describe tracks 
-   * that are probably made entirely of spoken words. Values between 0.33 and 
-   * 0.66 describe tracks that may contain both music and speech, either in 
-   * sections or layered, including such cases as rap music. Values below 0.33
-   * most likely represent music and other non-speech-like tracks.
-   */
+  /// Speechiness detects the presence of spoken words in a track. The more
+  /// exclusively speech-like the recording (e.g. talk show, audio book, poetry),
+  /// the closer to 1.0 the attribute value. Values above 0.66 describe tracks
+  /// that are probably made entirely of spoken words. Values between 0.33 and
+  /// 0.66 describe tracks that may contain both music and speech, either in
+  /// sections or layered, including such cases as rap music. Values below 0.33
+  /// most likely represent music and other non-speech-like tracks.
   double speechiness;
 
-  /**
-   * The overall estimated tempo of a track in beats per minute (BPM). In
-   * musical terminology, tempo is the speed or pace of a given piece and 
-   * derives directly from the average beat duration.
-   */
+  /// The overall estimated tempo of a track in beats per minute (BPM). In
+  /// musical terminology, tempo is the speed or pace of a given piece and
+  /// derives directly from the average beat duration.
   double tempo;
 
-  /**
-   * An estimated overall time signature of a track. The time signature (meter)
-   * is a notational convention to specify how many beats are in each bar (or 
-   * measure).
-   */
+  /// An estimated overall time signature of a track. The time signature (meter)
+  /// is a notational convention to specify how many beats are in each bar (or
+  /// measure).
   @JsonKey(name: 'time_signature')
   int timeSignature;
 
@@ -126,11 +103,9 @@ class AudioFeature extends Object {
   /// The Spotify URI for the track.
   String uri;
 
-  /**
-   * A measure from 0.0 to 1.0 describing the musical positiveness conveyed by
-   * a track. Tracks with high valence sound more positive (e.g. happy, 
-   * cheerful, euphoric), while tracks with low valence sound more negative 
-   * (e.g. sad, depressed, angry).
-   */
+  /// A measure from 0.0 to 1.0 describing the musical positiveness conveyed by
+  /// a track. Tracks with high valence sound more positive (e.g. happy,
+  /// cheerful, euphoric), while tracks with low valence sound more negative
+  /// (e.g. sad, depressed, angry).
   double valence;
 }

--- a/lib/src/models/category.dart
+++ b/lib/src/models/category.dart
@@ -2,7 +2,7 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Category extends Object {
-  Category() {}
+  Category();
 
   factory Category.fromJson(Map<String, dynamic> json) =>
       _$CategoryFromJson(json);

--- a/lib/src/models/error.dart
+++ b/lib/src/models/error.dart
@@ -5,7 +5,8 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class SpotifyError extends Object {
-  SpotifyError() {}
+  SpotifyError();
+
   factory SpotifyError.fromJson(Map<String, dynamic> json) =>
       _$SpotifyErrorFromJson(json);
 

--- a/lib/src/models/external_objects.dart
+++ b/lib/src/models/external_objects.dart
@@ -5,7 +5,8 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class ExternalUrls extends Object {
-  ExternalUrls() {}
+  ExternalUrls();
+
   factory ExternalUrls.fromJson(Map<String, dynamic> json) =>
       _$ExternalUrlsFromJson(json);
 
@@ -15,7 +16,8 @@ class ExternalUrls extends Object {
 
 @JsonSerializable(createToJson: false)
 class ExternalIds extends Object {
-  ExternalIds() {}
+  ExternalIds();
+
   factory ExternalIds.fromJson(Map<String, dynamic> json) =>
       _$ExternalIdsFromJson(json);
 

--- a/lib/src/models/followers.dart
+++ b/lib/src/models/followers.dart
@@ -5,17 +5,16 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Followers extends Object {
-  Followers() {}
+  Followers();
+
   factory Followers.fromJson(Map<String, dynamic> json) =>
       _$FollowersFromJson(json);
 
-  /**
-   * A link to the Web API endpoint providing full details of the followers; 
-   * null if not available. 
-   * 
-   * Please note that this will always be set to null, as the Web API does not 
-   * support it at the moment.
-   */
+  /// A link to the Web API endpoint providing full details of the followers;
+  /// null if not available.
+  ///
+  /// Please note that this will always be set to null, as the Web API does not
+  /// support it at the moment.
   String href;
 
   /// The total number of followers.

--- a/lib/src/models/image.dart
+++ b/lib/src/models/image.dart
@@ -5,7 +5,8 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Image extends Object {
-  Image() {}
+  Image();
+
   factory Image.fromJson(Map<String, dynamic> json) => _$ImageFromJson(json);
 
   /// The image height in pixels. If unknown: null or not returned.

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -6,11 +6,12 @@ part of spotify.models;
 typedef T ParserFunction<T>(dynamic object);
 
 Iterable<dynamic> itemsNativeFromJson(List<dynamic> json) => json;
-List<Map> itemsNativeToJson(Iterable<dynamic> items) => new List.from(items);
+List<Map> itemsNativeToJson(Iterable<dynamic> items) => List.from(items);
 
 @JsonSerializable(createToJson: false)
 class Paging<T> extends Object {
-  Paging() {}
+  Paging();
+
   factory Paging.fromJson(Map<String, dynamic> json) => _$PagingFromJson(json);
 
   /// A link to the Web API endpoint returning the full result of the request.

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-typedef T ParserFunction<T>(dynamic object);
+typedef ParserFunction<T> = T Function(dynamic object);
 
 Iterable<dynamic> itemsNativeFromJson(List<dynamic> json) => json;
 List<Map> itemsNativeToJson(Iterable<dynamic> items) => List.from(items);

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -33,7 +33,7 @@ class Player extends Object {
 
 @JsonSerializable(createToJson: false)
 class PlayerContext extends Object {
-  PlayerContext() {}
+  PlayerContext();
 
   factory PlayerContext.fromJson(Map<String, dynamic> json) =>
       _$PlayerContextFromJson(json);

--- a/lib/src/models/playlist.dart
+++ b/lib/src/models/playlist.dart
@@ -5,11 +5,13 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Playlist extends Object implements PlaylistSimple {
-  Playlist() {}
+  Playlist();
+
   factory Playlist.fromJson(Map<String, dynamic> json) =>
       _$PlaylistFromJson(json);
 
   /// true if the owner allows other users to modify the playlist.
+  @override
   bool collaborative;
 
   /// The playlist description. Only returned for modified, verified playlists,
@@ -18,15 +20,18 @@ class Playlist extends Object implements PlaylistSimple {
 
   /// Known external URLs for this playlist.
   @JsonKey(name: 'external_urls')
+  @override
   ExternalUrls externalUrls;
 
   /// Information about the followers of the playlist.
   Followers followers;
 
   /// A link to the Web API endpoint providing full details of the playlist.
+  @override
   String href;
 
   /// The Spotify ID for the playlist.
+  @override
   String id;
 
   /// Images for the playlist. The array may be empty or contain up to three
@@ -35,22 +40,27 @@ class Playlist extends Object implements PlaylistSimple {
   ///
   /// Note: If returned, the source URL for the image (url) is temporary and
   /// will expire in less than a day.
+  @override
   List<Image> images;
 
   /// The name of the playlist.
+  @override
   String name;
 
   /// The user who owns the playlist
+  @override
   User owner;
 
   /// The playlist's public/private status: [true] the playlist is public,
   /// [false] the playlist is private, null the playlist status is not relevant.
   /// For more about public/private status, see Working with Playlists.
+  @override
   bool public;
 
   /// The version identifier for the current playlist. Can be supplied in other
   /// requests to target a specific playlist version
   @JsonKey(name: 'snapshot_id')
+  @override
   String snapshotId;
 
   /// Use [Playlist.tracks]
@@ -62,15 +72,17 @@ class Playlist extends Object implements PlaylistSimple {
   List<Track> tracks;
 
   /// The object type: "playlist"
+  @override
   String type;
 
   /// The Spotify URI for the playlist.
+  @override
   String uri;
 }
 
 @JsonSerializable(createToJson: false)
 class PlaylistSimple extends Object {
-  PlaylistSimple() {}
+  PlaylistSimple();
   factory PlaylistSimple.fromJson(Map<String, dynamic> json) =>
       _$PlaylistSimpleFromJson(json);
 
@@ -126,7 +138,7 @@ class PlaylistSimple extends Object {
 
 @JsonSerializable(createToJson: false)
 class PlaylistsFeatured extends Object {
-  PlaylistsFeatured() {}
+  PlaylistsFeatured();
   factory PlaylistsFeatured.fromJson(Map<String, dynamic> json) =>
       _$PlaylistsFeaturedFromJson(json);
 
@@ -136,7 +148,7 @@ class PlaylistsFeatured extends Object {
 
 @JsonSerializable(createToJson: false)
 class PlaylistTrack extends Object {
-  PlaylistTrack() {}
+  PlaylistTrack();
   factory PlaylistTrack.fromJson(Map<String, dynamic> json) =>
       _$PlaylistTrackFromJson(json);
 

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -5,47 +5,44 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class Track extends Object implements TrackSimple {
-  Track() {}
+  Track();
+
   factory Track.fromJson(Map<String, dynamic> json) => _$TrackFromJson(json);
 
-  /**
-   * The album on which the track appears. The album object includes a link in
-   * [href] to full information about the album. 
-   */
+  /// The album on which the track appears. The album object includes a link
+  /// in [href] to full information about the album.
   AlbumSimple album;
 
-  /**
-   * The artists who performed the track. Each artist object includes a link in
-   * [href] to more detailed information about the artist. 
-   */
+  /// The artists who performed the track. Each artist object includes a link
+  /// in [href] to more detailed information about the artist.
+  @override
   List<Artist> artists;
 
-  /**
-   * A list of the countries in which the track can be played, identified by 
-   * their ISO 3166-1 alpha-2 code.
-   */
+  /// A list of the countries in which the track can be played, identified by
+  /// their ISO 3166-1 alpha-2 code.
   @JsonKey(name: 'available_markets')
+  @override
   List<String> availableMarkets;
 
-  /**
-   * The disc number 
-   * (usually [1] unless the album consists of more than one disc)
-   */
+  /// The disc number
+  /// (usually [1] unless the album consists of more than one disc)
   @JsonKey(name: 'disc_number')
+  @override
   int discNumber;
 
   /// The track length in milliseconds.
   @JsonKey(name: 'duration_ms')
+  @override
   int durationMs;
 
   /// The track length
   @JsonKey(ignore: true)
-  Duration get duration => new Duration(milliseconds: durationMs);
+  @override
+  Duration get duration => Duration(milliseconds: durationMs);
 
-  /**
-   * Whether or not the track has explicit lyrics 
-   * ([true] = yes it does; [false] = no it does not OR unknown). 
-   */
+  /// Whether or not the track has explicit lyrics
+  /// ([true] = yes it does; [false] = no it does not OR unknown).
+  @override
   bool explicit;
 
   /// Known external IDs for this track.
@@ -54,95 +51,90 @@ class Track extends Object implements TrackSimple {
 
   /// Known external URLs for this track.
   @JsonKey(name: 'external_urls')
+  @override
   ExternalUrls externalUrls;
 
   /// A link to the Web API endpoint providing full details of the track.
+  @override
   String href;
 
   /// The Spotify ID for the track.
+  @override
   String id;
 
-  /**
-   * Part of the response when Track Relinking is applied. If true, the track 
-   * is playable in the given market. Otherwise false.
-   */
+  /// Part of the response when Track Relinking is applied. If true, the track
+  /// is playable in the given market. Otherwise false.
   @JsonKey(name: 'is_playable')
+  @override
   bool isPlayable;
 
-  /**
-   * Part of the response when Track Relinking is applied and is only part of 
-   * the response if the track linking, in fact, exists. The requested track 
-   * has been replaced with a different track. The track in the linked_from 
-   * object contains information about the originally requested track.
-   */
+  /// Part of the response when Track Relinking is applied and is only part of
+  /// the response if the track linking, in fact, exists. The requested track
+  /// has been replaced with a different track. The track in the linked_from
+  /// object contains information about the originally requested track.
   @JsonKey(name: 'linked_from')
+  @override
   TrackLink linkedFrom;
 
   /// The name of the track.
+  @override
   String name;
 
-  /**
-   * The popularity of the track. The value will be between 0 and 100, with 100 
-   * being the most popular.
-   * 
-   * The popularity of a track is a value between 0 and 100, with 100 being the 
-   * most popular. The popularity is calculated by algorithm and is based, in 
-   * the most part, on the total number of plays the track has had and how 
-   * recent those plays are.
-   * 
-   * Generally speaking, songs that are being played a lot now will have a 
-   * higher popularity than songs that were played a lot in the past. Duplicate 
-   * tracks (e.g. the same track from a single and an album) are rated 
-   * independently. Artist and album popularity is derived mathematically from 
-   * track popularity. Note that the popularity value may lag actual popularity 
-   * by a few days: the value is not updated in real time.
-   */
+  /// The popularity of the track. The value will be between 0 and 100, with 100
+  /// being the most popular.
+  ///
+  /// The popularity of a track is a value between 0 and 100, with 100 being the
+  /// most popular. The popularity is calculated by algorithm and is based, in
+  /// the most part, on the total number of plays the track has had and how
+  /// recent those plays are.
+  ///
+  /// Generally speaking, songs that are being played a lot now will have a
+  /// higher popularity than songs that were played a lot in the past. Duplicate
+  /// tracks (e.g. the same track from a single and an album) are rated
+  /// independently. Artist and album popularity is derived mathematically from
+  /// track popularity. Note that the popularity value may lag actual popularity
+  /// by a few days: the value is not updated in real time.
   int popularity;
 
-  /**
-   * A URL to a 30 second preview (MP3 format) of the track. [null] if not 
-   * available.
-   */
+  /// A URL to a 30 second preview (MP3 format) of the track. [null] if not
+  /// available.
   @JsonKey(name: 'preview_url')
+  @override
   String previewUrl;
 
-  /**
-   * The number of the track. If an album has several discs, the track number 
-   * is the number on the specified disc. 
-   */
+  /// The number of the track. If an album has several discs, the track number
+  /// is the number on the specified disc.
   @JsonKey(name: 'track_number')
+  @override
   int trackNumber;
 
   /// The object type: "track".
+  @override
   String type;
 
   /// The Spotify URI for the track.
+  @override
   String uri;
 }
 
 @JsonSerializable(createToJson: false)
 class TrackSimple extends Object {
-  TrackSimple() {}
+  TrackSimple();
+
   factory TrackSimple.fromJson(Map<String, dynamic> json) =>
       _$TrackSimpleFromJson(json);
 
-  /**
-   * The artists who performed the track. Each artist object includes a link in
-   * [href] to more detailed information about the artist. 
-   */
+  /// The artists who performed the track. Each artist object includes a link
+  /// in [href] to more detailed information about the artist.
   List<Artist> artists;
 
-  /**
-   * A list of the countries in which the track can be played, identified by 
-   * their ISO 3166-1 alpha-2 code.
-   */
+  /// A list of the countries in which the track can be played, identified by
+  /// their ISO 3166-1 alpha-2 code.
   @JsonKey(name: 'available_markets')
   List<String> availableMarkets;
 
-  /**
-   * The disc number 
-   * (usually [1] unless the album consists of more than one disc)
-   */
+  /// The disc number
+  /// (usually [1] unless the album consists of more than one disc)
   @JsonKey(name: 'disc_number')
   int discNumber;
 
@@ -152,12 +144,10 @@ class TrackSimple extends Object {
 
   /// The track length
   @JsonKey(ignore: true)
-  Duration get duration => new Duration(milliseconds: durationMs);
+  Duration get duration => Duration(milliseconds: durationMs);
 
-  /**
-   * Whether or not the track has explicit lyrics 
-   * ([true] = yes it does; [false] = no it does not OR unknown). 
-   */
+  /// Whether or not the track has explicit lyrics
+  /// ([true] = yes it does; [false] = no it does not OR unknown).
   bool explicit;
 
   /// Known external URLs for this track.
@@ -170,36 +160,28 @@ class TrackSimple extends Object {
   /// The Spotify ID for the track.
   String id;
 
-  /**
-   * Part of the response when Track Relinking is applied. If true, the track 
-   * is playable in the given market. Otherwise false.
-   */
+  /// Part of the response when Track Relinking is applied. If true, the track
+  /// is playable in the given market. Otherwise false.
   @JsonKey(name: 'is_playable')
   bool isPlayable;
 
-  /**
-   * Part of the response when Track Relinking is applied and is only part of 
-   * the response if the track linking, in fact, exists. The requested track 
-   * has been replaced with a different track. The track in the linked_from 
-   * object contains information about the originally requested track.
-   */
+  /// Part of the response when Track Relinking is applied and is only part of
+  /// the response if the track linking, in fact, exists. The requested track
+  /// has been replaced with a different track. The track in the linked_from
+  /// object contains information about the originally requested track.
   @JsonKey(name: 'linked_from')
   TrackLink linkedFrom;
 
   /// The name of the track.
   String name;
 
-  /**
-   * A URL to a 30 second preview (MP3 format) of the track. [null] if not 
-   * available.
-   */
+  /// A URL to a 30 second preview (MP3 format) of the track. [null] if not
+  /// available.
   @JsonKey(name: 'preview_url')
   String previewUrl;
 
-  /**
-   * The number of the track. If an album has several discs, the track number 
-   * is the number on the specified disc. 
-   */
+  /// The number of the track. If an album has several discs, the track number
+  /// is the number on the specified disc.
   @JsonKey(name: 'track_number')
   int trackNumber;
 
@@ -213,7 +195,7 @@ class TrackSimple extends Object {
 /// A song saved in a Spotify user’s “Your Music” library
 @JsonSerializable(createToJson: false)
 class TrackSaved extends Object {
-  TrackSaved() {}
+  TrackSaved();
   factory TrackSaved.fromJson(Map<String, dynamic> json) =>
       _$TrackSavedFromJson(json);
 
@@ -227,7 +209,7 @@ class TrackSaved extends Object {
 
 @JsonSerializable(createToJson: false)
 class TrackLink extends Object {
-  TrackLink() {}
+  TrackLink();
   factory TrackLink.fromJson(Map<String, dynamic> json) =>
       _$TrackLinkFromJson(json);
 
@@ -250,7 +232,7 @@ class TrackLink extends Object {
 
 @JsonSerializable(createToJson: false)
 class TracksLink extends Object {
-  TracksLink() {}
+  TracksLink();
   factory TracksLink.fromJson(Map<String, dynamic> json) =>
       _$TracksLinkFromJson(json);
 

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -5,7 +5,7 @@ part of spotify.models;
 
 @JsonSerializable(createToJson: false)
 class User extends Object implements UserPublic {
-  User() {}
+  User();
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
   /// The user's date-of-birth.
@@ -21,6 +21,7 @@ class User extends Object implements UserPublic {
 
   /// The name displayed on the user's profile. null if not available.
   @JsonKey(name: 'display_name')
+  @override
   String displayName;
 
   /// The user's email address, as entered by the user when creating their
@@ -38,15 +39,19 @@ class User extends Object implements UserPublic {
   //Map<String, String> externalUrls;
 
   /// Information about the followers of this user.
+  @override
   Followers followers;
 
   /// A link to the Web API endpoint for this user.
+  @override
   String href;
 
   /// The Spotify user ID for this user.
+  @override
   String id;
 
   /// The user's profile image.
+  @override
   List<Image> images;
 
   /// The user's Spotify subscription level: "premium", "free", etc. (The
@@ -57,15 +62,17 @@ class User extends Object implements UserPublic {
   String product;
 
   /// The object type: "user"
+  @override
   String type;
 
   /// The Spotify URI for this user.
+  @override
   String uri;
 }
 
 @JsonSerializable(createToJson: false)
 class UserPublic extends Object {
-  UserPublic() {}
+  UserPublic();
   factory UserPublic.fromJson(Map<String, dynamic> json) =>
       _$UserPublicFromJson(json);
 

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -6,8 +6,8 @@ part of spotify;
 abstract class SpotifyApiBase {
   static const String _baseUrl = 'https://api.spotify.com';
   static const String _tokenUrl = 'https://accounts.spotify.com/api/token';
-  static const String _authorizationUrl = 'https://accounts.spotify.com/authorize';
-
+  static const String _authorizationUrl =
+      'https://accounts.spotify.com/authorize';
 
   FutureOr<BaseClient> _client;
   Artists _artists;
@@ -18,7 +18,6 @@ abstract class SpotifyApiBase {
   Search _search;
   AudioFeatures _audioFeatures;
   Categories _categories;
-
 
   Artists get artists => _artists;
 
@@ -37,26 +36,29 @@ abstract class SpotifyApiBase {
 
   SpotifyApiBase.fromClient(FutureOr<BaseClient> client) {
     _client = client;
-    _artists = new Artists(this);
-    _albums = new Albums(this);
-    _tracks = new Tracks(this);
-    _playlists = new Playlists(this);
-    _users = new Users(this);
-    _search = new Search(this);
-    _audioFeatures = new AudioFeatures(this);
+    _artists = Artists(this);
+    _albums = Albums(this);
+    _tracks = Tracks(this);
+    _playlists = Playlists(this);
+    _users = Users(this);
+    _search = Search(this);
+    _audioFeatures = AudioFeatures(this);
     _categories = Categories(this);
   }
 
-  SpotifyApiBase(SpotifyApiCredentials credentials,
-                 [BaseClient httpClient]):
-        this.fromClient(clientCredentialsGrant(
-          Uri.parse(SpotifyApiBase._tokenUrl),
-          credentials.clientId, credentials.clientSecret, httpClient: httpClient));
+  SpotifyApiBase(SpotifyApiCredentials credentials, [BaseClient httpClient])
+      : this.fromClient(clientCredentialsGrant(
+            Uri.parse(SpotifyApiBase._tokenUrl),
+            credentials.clientId,
+            credentials.clientSecret,
+            httpClient: httpClient));
 
-  SpotifyApiBase.fromAuthCodeGrant(AuthorizationCodeGrant grant, String responseUri) :
-      this.fromClient(grant.handleAuthorizationResponse(Uri.parse(responseUri).queryParameters));
+  SpotifyApiBase.fromAuthCodeGrant(
+      AuthorizationCodeGrant grant, String responseUri)
+      : this.fromClient(grant.handleAuthorizationResponse(
+            Uri.parse(responseUri).queryParameters));
 
-    static AuthorizationCodeGrant authorizationCodeGrant(
+  static AuthorizationCodeGrant authorizationCodeGrant(
       SpotifyApiCredentials credentials, BaseClient httpClient) {
     return AuthorizationCodeGrant(
         credentials.clientId,
@@ -70,34 +72,37 @@ abstract class SpotifyApiBase {
     return _getImpl('${_baseUrl}/$path', const {});
   }
 
-  Future<String> _post(String path, [String body='']) {
+  Future<String> _post(String path, [String body = '']) {
     return _postImpl('${_baseUrl}/$path', const {}, body);
   }
 
-  Future<String> _delete(String path, [String body='']) {
+  Future<String> _delete(String path, [String body = '']) {
     return _deleteImpl('${_baseUrl}/$path', const {}, body);
   }
 
-  Future<String> _put(String path, [String body='']) {
+  Future<String> _put(String path, [String body = '']) {
     return _putImpl('${_baseUrl}/$path', const {}, body);
   }
 
   Future<String> _getImpl(String url, Map<String, String> headers) async {
-      final response = await (await _client).get(url, headers: headers);
-      return handleErrors(response);
-  }
-
-    Future<String> _postImpl(
-      String url, Map<String, String> headers, dynamic body) async {
-    var response = await (await _client).post(url, headers: headers, body: body);
+    final response = await (await _client).get(url, headers: headers);
     return handleErrors(response);
   }
 
-    Future<String> _deleteImpl(String url, Map<String, String> headers, body) async {
-    final request = Request("DELETE", Uri.parse(url));
+  Future<String> _postImpl(
+      String url, Map<String, String> headers, dynamic body) async {
+    var response =
+        await (await _client).post(url, headers: headers, body: body);
+    return handleErrors(response);
+  }
+
+  Future<String> _deleteImpl(
+      String url, Map<String, String> headers, body) async {
+    final request = Request('DELETE', Uri.parse(url));
     request.headers.addAll(headers);
     request.body = body;
-    final response = await Response.fromStream(await (await _client).send(request));
+    final response =
+        await Response.fromStream(await (await _client).send(request));
     return handleErrors(response);
   }
 
@@ -107,12 +112,11 @@ abstract class SpotifyApiBase {
     return handleErrors(response);
   }
 
-
   String handleErrors(Response response) {
     final responseBody = utf8.decode(response.bodyBytes);
     if (response.statusCode >= 400) {
       var jsonMap = json.decode(responseBody);
-      throw new SpotifyException.fromSpotify(
+      throw SpotifyException.fromSpotify(
         SpotifyError.fromJson(jsonMap['error']),
       );
     }

--- a/lib/src/spotify_browser.dart
+++ b/lib/src/spotify_browser.dart
@@ -3,15 +3,18 @@
 
 part of spotify;
 
-
-class SpotifyApi extends SpotifyApiBase{
-  SpotifyApi(SpotifyApiCredentials credentials) : super(credentials, http.BrowserClient());
+class SpotifyApi extends SpotifyApiBase {
+  SpotifyApi(SpotifyApiCredentials credentials)
+      : super(credentials, http.BrowserClient());
 
   SpotifyApi.fromClient(FutureOr<Client> client) : super.fromClient(client);
 
-  SpotifyApi.fromAuthCodeGrant(AuthorizationCodeGrant grant, String responseUri) : super.fromAuthCodeGrant(grant, responseUri);
+  SpotifyApi.fromAuthCodeGrant(AuthorizationCodeGrant grant, String responseUri)
+      : super.fromAuthCodeGrant(grant, responseUri);
 
-  static AuthorizationCodeGrant authorizationCodeGrant(SpotifyApiCredentials credentials) {
-    return SpotifyApiBase.authorizationCodeGrant(credentials, http.BrowserClient());
+  static AuthorizationCodeGrant authorizationCodeGrant(
+      SpotifyApiCredentials credentials) {
+    return SpotifyApiBase.authorizationCodeGrant(
+        credentials, http.BrowserClient());
   }
 }

--- a/lib/src/spotify_io.dart
+++ b/lib/src/spotify_io.dart
@@ -3,14 +3,17 @@
 
 part of spotify;
 
-class SpotifyApi extends SpotifyApiBase{
-  SpotifyApi(SpotifyApiCredentials credentials) : super(credentials, http.Client());
+class SpotifyApi extends SpotifyApiBase {
+  SpotifyApi(SpotifyApiCredentials credentials)
+      : super(credentials, http.Client());
 
   SpotifyApi.fromClient(FutureOr<Client> client) : super.fromClient(client);
 
-  SpotifyApi.fromAuthCodeGrant(AuthorizationCodeGrant grant, String responseUri) : super.fromAuthCodeGrant(grant, responseUri);
+  SpotifyApi.fromAuthCodeGrant(AuthorizationCodeGrant grant, String responseUri)
+      : super.fromAuthCodeGrant(grant, responseUri);
 
-  static AuthorizationCodeGrant authorizationCodeGrant(SpotifyApiCredentials credentials) {
+  static AuthorizationCodeGrant authorizationCodeGrant(
+      SpotifyApiCredentials credentials) {
     return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client());
   }
 }

--- a/lib/src/spotify_mock.dart
+++ b/lib/src/spotify_mock.dart
@@ -1,8 +1,8 @@
 part of spotify;
 
-
-class SpotifyApiMock extends SpotifyApiBase{
-  SpotifyApiMock(SpotifyApiCredentials credentials) : super.fromClient(MockClient());
+class SpotifyApiMock extends SpotifyApiBase {
+  SpotifyApiMock(SpotifyApiCredentials credentials)
+      : super.fromClient(MockClient());
 
   MockHttpError _mockHttpError;
 
@@ -14,28 +14,28 @@ class SpotifyApiMock extends SpotifyApiBase{
 class MockClient implements http.BaseClient {
   MockClient([MockHttpError mockHttpError]) : _mockHttpError = mockHttpError;
 
-  MockHttpError _mockHttpError;
+  final MockHttpError _mockHttpError;
 
   String _readPath(String url) {
     var regexString = url.contains('api.spotify.com')
         ? r'api.spotify.com\/([A-Za-z0-9/]+)\??'
         : r'api/([A-Za-z0-9/]+)\??';
 
-    var regex = new RegExp(regexString);
+    var regex = RegExp(regexString);
     var partialPath = regex.firstMatch(url).group(1);
-    var file = new File('test/data/$partialPath.json');
+    var file = File('test/data/$partialPath.json');
 
     return file.readAsStringSync();
   }
 
   @override
   void close() {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   @override
   Future<http.Response> delete(url, {Map<String, String> headers}) {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   @override
@@ -48,13 +48,13 @@ class MockClient implements http.BaseClient {
 
   @override
   Future<http.Response> head(url, {Map<String, String> headers}) {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   @override
   Future<http.Response> patch(url,
       {Map<String, String> headers, body, Encoding encoding}) {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   @override
@@ -69,33 +69,33 @@ class MockClient implements http.BaseClient {
   @override
   Future<http.Response> put(url,
       {Map<String, String> headers, body, Encoding encoding}) {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   @override
   Future<String> read(url, {Map<String, String> headers}) {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   @override
   Future<Uint8List> readBytes(url, {Map<String, String> headers}) {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
-    throw "Not implemented";
+    throw 'Not implemented';
   }
 
   http.Response createSuccessResponse(String body) {
     /// necessary due to using Latin-1 encoding per default.
     /// https://stackoverflow.com/questions/52990816/dart-json-encodedata-can-not-accept-other-language
-    return new http.Response(body, 200,
+    return http.Response(body, 200,
         headers: {'Content-Type': 'application/json; charset=utf-8'});
   }
 
   http.Response createErrorResponse(MockHttpError error) {
-    return new http.Response(
+    return http.Response(
         _wrapMessageToJson(error.statusCode, error.message), error.statusCode,
         headers: {'Content-Type': 'application/json; charset=utf-8'});
   }

--- a/lib/src/spotify_mock.dart
+++ b/lib/src/spotify_mock.dart
@@ -101,7 +101,7 @@ class MockClient implements http.BaseClient {
   }
 
   String _wrapMessageToJson(int statusCode, String message) =>
-      "{ \"error\": {\"status\":$statusCode,\"message\": \"$message\"}}";
+      '{ \"error\": {\"status\":$statusCode,\"message\": \"$message\"}}';
 }
 
 class MockHttpError {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,3 +24,4 @@ dev_dependencies:
   test: ^1.5.1
   build_runner: ^1.1.1
   json_serializable: ^3.2.5
+  pedantic: ^1.9.0

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -39,14 +39,14 @@ Future main() async {
 
     test('get_error', () async {
       spotify.mockHttpError =
-          MockHttpError(statusCode: 401, message: "Bad Request");
+          MockHttpError(statusCode: 401, message: 'Bad Request');
       try {
         await spotify.artists.get('0TnOYISbd1XYRBk9myaseg');
       } catch (e) {
         expect(e, isA<SpotifyException>());
-        SpotifyException se = e as SpotifyException;
+        var se = e as SpotifyException;
         expect(se.status, 401);
-        expect(se.message, "Bad Request");
+        expect(se.message, 'Bad Request');
       }
     });
   });
@@ -59,14 +59,14 @@ Future main() async {
 
     test('get_error', () async {
       spotify.mockHttpError =
-          new MockHttpError(statusCode: 401, message: "Bad Request");
+          MockHttpError(statusCode: 401, message: 'Bad Request');
       try {
         await spotify.search.get('metallica').first();
       } catch (e) {
         expect(e, isA<SpotifyException>());
-        SpotifyException se = e as SpotifyException;
+        var se = e as SpotifyException;
         expect(se.status, 401);
-        expect(se.message, "Bad Request");
+        expect(se.message, 'Bad Request');
       }
     });
   });


### PR DESCRIPTION
If you go to this package's [Analysis tab](https://pub.dev/packages/spotify#-analysis-tab-) on pub.dev, there's a big list of health suggestions that could be easily addressed to improve the package's overall quality score.

Changes in this PR:
* Add [pedantic](https://pub.dev/packages/pedantic) as a dev dependency, since it's the go-to static analysis tool for Dart, used by Google and [over 1300 packages](https://pub.dev/packages?q=dependency%3Apedantic)
* Address roughly 200 issues that were discovered after implementing **pedantic**'s new linter rules
* Add `// ignore: unused_element` for 2 issues that don't seem like they need to be fixed

According to a local run of [pana](https://pub.dev/packages/pana#-readme-tab-), the tool used to generate package quality scores on pub.dev, these changes improve the package's `Health` score from 75 to 100.