### PR TITLE
Add new authorization details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Unfortunately, there's not a universal example for implementing the imaginary fu
 
 For a Flutter app, there's two popular approaches:
 1. Launch a browser using [url_launcher][url_launcher] and listen for a deeplink redirect using [uni_links][uni_links]. The device running the Flutter app will function as the authorization server and handle the redirect. The redirect URI should look something like `com.app://auth`.
-2. Launch a webview inside the app and listen for a redirect using [webview_flutter][webview_flutter]. This approach requires redirecting to an external authorization server, such as a backend service or serverless function. The redirect URI should be a normal URL, like `https://example.com/auth`, that points to the authorization server.
+2. Launch a WebView inside the app and listen for a redirect using [webview_flutter][webview_flutter]. This approach requires redirecting to an external authorization server, such as a backend service or serverless function. The redirect URI should be a normal URL, like `https://example.com/auth`, that points to the authorization server.
 
-For a Dart app, the approach completely depends on how it's able to access a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
+For a Dart app, the approach depends on the available options for accessing a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
 
 ## Features and bugs
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ SpotifyApi getSpotifyApi() async {
   final credentials = SpotifyApiCredentials(clientId, clientSecret);
   final grant = SpotifyApi.authorizationCodeGrant(credentials);
 
-  // The URI to redirect to after the user grants or denies permission.
-  // This URI must be in your Spotify application's Redirect URI whitelist.
+  // The URI to redirect to after the user grants or denies permission. It must
+  // be in your Spotify application's Redirect URI whitelist. This URI can
+  // either be a web address pointing to an authorization server or a fabricated
+  // URI that allows the client device to function as an authorization server.
   final redirectUri = 'https://example.com/auth';
 
   // See https://developer.spotify.com/documentation/general/guides/scopes/
@@ -65,13 +67,48 @@ SpotifyApi getSpotifyApi() async {
 }
 ```
 
-Unfortunately, there's not a universal example for implementing the imaginary functions, `redirect` and `listen`, because different options exist for each platform.
+<details>
+  <summary>Click here to learn how to implement the imaginary functions mentioned above.</summary>
+  
+  -----
+  
+  Unfortunately, there's not a universal example for implementing the imaginary functions, `redirect` and `listen`, because different options exist for each platform.
+      
+  For Flutter apps, there's two popular approaches:
+  1. Launch a browser using [url_launcher][url_launcher] and listen for a redirect using [uni_links][uni_links].
+        ```
+        if (await canLaunch(authUri)) {
+          await launch(authUri);
+        }
 
-For a Flutter app, there's two popular approaches:
-1. Launch a browser using [url_launcher][url_launcher] and listen for a deeplink redirect using [uni_links][uni_links]. The device running the Flutter app will function as the authorization server and handle the redirect. The redirect URI should look something like `com.app://auth`.
-2. Launch a WebView inside the app and listen for a redirect using [webview_flutter][webview_flutter]. This approach requires redirecting to an external authorization server, such as a backend service or serverless function. The redirect URI should be a normal URL, like `https://example.com/auth`, that points to the authorization server.
+        ...
+    
+        final linksStream = getLinksStream().listen((String link) async {
+          if (link.startsWith(redirectUri) {
+            responseUri = link;
+          }
+        });
+        ```
 
-For a Dart app, the approach depends on the available options for accessing a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
+  2. Launch a WebView inside the app and listen for a redirect using [webview_flutter][webview_flutter].
+        ```
+        WebView(
+          javascriptMode: JavascriptMode.unrestricted,
+          initialUrl: authUri,
+          navigationDelegate: (navReq) {
+            if (navReq.url.startsWith(redirectUri)) {
+              responseUri = navReq.url;
+              return NavigationDecision.prevent;
+            }
+            
+            return NavigationDecision.navigate;
+          },
+          ...
+        );
+        ```
+   
+  For Dart apps, the approach depends on the available options for accessing a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
+</details>
 
 ## Features and bugs
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A dart library for interfacing with the Spotify API.
 
 ## Usage
 
-A simple usage example:
+### Simple Example
 
 ```dart
 import 'package:spotify/spotify.dart';
@@ -17,7 +17,10 @@ void main() async {
 }
 ```
 
-### Client Credentials Flow
+### Authorization
+#### Client Credentials Flow
+This flow is recommended when you only need access to public Spotify data. It cannot be used to access or manage a user's private data.
+
 ```dart
 SpotifyApi getSpotifyApi() {
   final credentials = SpotifyApiCredentials(clientId, clientSecret);
@@ -25,21 +28,50 @@ SpotifyApi getSpotifyApi() {
 }
 ```
 
-### Authorization Code
+#### Authorization Code Flow
+This flow is suitable for long-running applications when you need to access or manage a user's private data. The Authorization Code Flow is a complex process, so it's highly recommended to read through [Spotify's Authorization Guide][spotify_auth] before attempting. Note that this package simplifies the creation of the authorization URI and the process of requesting tokens after receiving an authorization code.
+
 ```dart
 SpotifyApi getSpotifyApi() async {
   final credentials = SpotifyApiCredentials(clientId, clientSecret);
-  grant = SpotifyApi.authorizationCodeGrant(credentials);
-  // *** from dart-lang/oauth2 package
-  // `redirect` is an imaginary function that redirects the resource
-  // owner's browser.
-  await redirect(grant.getAuthorizationUrl(redirectUrl));
-  // Another imaginary function that listens for a request to `redirectUrl`.
-  final requestUri = await listen(redirectUrl);
-  // ***
-  return SpotifyApi.fromAuthCodeGrant(WelcomeScreen.grant, requestUri);
+  final grant = SpotifyApi.authorizationCodeGrant(credentials);
+
+  // The URI to redirect to after the user grants or denies permission.
+  // This URI must be in your Spotify application's Redirect URI whitelist.
+  final redirectUri = 'https://example.com/auth';
+
+  // See https://developer.spotify.com/documentation/general/guides/scopes/
+  // for a complete list of these Spotify authorization permissions. If no
+  // scopes are specified, only public Spotify information will be available.
+  final scopes = ['user-read-email', 'user-library-read'];
+
+  var authUri = grant.getAuthorizationUrl(
+    Uri.parse(redirectUri),
+    scopes: scopes, // scopes are optional
+  );
+
+  // `redirect` is an imaginary function that redirects the resource owner's
+  // browser to the `authUri` on the authorization server. Once the resource
+  // owner has authorized, they'll be redirected to the `redirectUri` with an
+  // authorization code. The exact implementation varies across platforms.
+  await redirect(authUri);
+
+  // `listen` is another imaginary function that listens for a request to
+  // `redirectUri` after the user grants or denies permission. Again, the
+  // exact implementation varies across platforms.
+  final responseUri = await listen(redirectUri);
+
+  return SpotifyApi.fromAuthCodeGrant(grant, responseUri);
 }
 ```
+#### Implementation Approaches
+Unfortunately, there's no universal example for implementing the imaginary functions, `redirect` and `listen`, because different options exist for each platform.
+
+For a Flutter app, there's two popular approaches:
+1. Launch a browser using [url_launcher][url_launcher] and listen for a deeplink redirect using [uni_links][uni_links]. The device running the Flutter app will function as the authorization server and handle the redirect. The redirect URI should look something like `com.app://auth`.
+2. Launch a webview inside the app and listen for a redirect using [webview_flutter][webview_flutter]. This approach requires redirecting to an external authorization server, such as a backend service or serverless function. The redirect URI should be a normal URL, like `https://example.com/auth`, that points to the authorization server.
+
+For a Dart app, the approach completely depends on how it's able to access a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
 
 ## Features and bugs
 
@@ -50,7 +82,17 @@ Please file feature requests and bugs at the [issue tracker][tracker].
 ## Development
 
 ### Generating JSON Serializers
+Run `pub run build_runner build` to generate JSON serializers via [json_serializable][json_serializable].
+Run `pub run build_runner watch` to continuously rebuild serializers in the background when files are updated.
 
-Run `pub run build_runner build` to generate JSON serilizers via [json_serializable][json].
+### Running unit tests
+Run `pub run test` to run all of the unit tests in `test/spotify_test.dart`.
 
-[json]: https://pub.dartlang.org/packages/json_serializable
+### Running example code
+Run `pub run example/example` to run the example code. You'll need to modify `example/example.dart` to use your Spotify client ID and secret.
+
+[json_serializable]: https://pub.dartlang.org/packages/json_serializable
+[spotify_auth]: https://developer.spotify.com/documentation/general/guides/authorization-guide/
+[webview_flutter]: https://pub.dev/packages/webview_flutter
+[uni_links]: https://pub.dev/packages/uni_links
+[url_launcher]: https://pub.dev/packages/url_launcher

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ SpotifyApi getSpotifyApi() async {
         );
         ```
    
-  For Dart apps, the approach depends on the available options for accessing a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
+  For Dart apps, the best approach depends on the available options for accessing a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
 </details>
 
 ## Features and bugs

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Please file feature requests and bugs at the [issue tracker][tracker].
 Run `pub run build_runner build` to generate JSON serializers via [json_serializable][json_serializable].
 Run `pub run build_runner watch` to continuously rebuild serializers in the background when files are updated.
 
-### Running unit tests
-Run `pub run test` to run all of the unit tests in `test/spotify_test.dart`.
+### Running tests
+Run `pub run test` to run all of the tests in `test/spotify_test.dart`.
 
 ### Running example code
 Run `pub run example/example` to run the example code. You'll need to modify `example/example.dart` to use your Spotify client ID and secret.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ SpotifyApi getSpotifyApi() async {
   return SpotifyApi.fromAuthCodeGrant(grant, responseUri);
 }
 ```
-#### Implementation Approaches
-Unfortunately, there's no universal example for implementing the imaginary functions, `redirect` and `listen`, because different options exist for each platform.
+
+Unfortunately, there's not a universal example for implementing the imaginary functions, `redirect` and `listen`, because different options exist for each platform.
 
 For a Flutter app, there's two popular approaches:
 1. Launch a browser using [url_launcher][url_launcher] and listen for a deeplink redirect using [uni_links][uni_links]. The device running the Flutter app will function as the authorization server and handle the redirect. The redirect URI should look something like `com.app://auth`.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ SpotifyApi getSpotifyApi() async {
       
   For Flutter apps, there's two popular approaches:
   1. Launch a browser using [url_launcher][url_launcher] and listen for a redirect using [uni_links][uni_links].
-        ```
+      ```dart
         if (await canLaunch(authUri)) {
           await launch(authUri);
         }
@@ -88,10 +88,10 @@ SpotifyApi getSpotifyApi() async {
             responseUri = link;
           }
         });
-        ```
+      ```
 
   2. Launch a WebView inside the app and listen for a redirect using [webview_flutter][webview_flutter].
-        ```
+      ```dart
         WebView(
           javascriptMode: JavascriptMode.unrestricted,
           initialUrl: authUri,
@@ -105,7 +105,7 @@ SpotifyApi getSpotifyApi() async {
           },
           ...
         );
-        ```
+      ```
    
   For Dart apps, the best approach depends on the available options for accessing a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
 </details>


### PR DESCRIPTION
This PR adds more details about Spotify authorization to the README based on the discussion in https://github.com/rinukkusu/spotify-dart/issues/37.

I've personally used every approach I mentioned for Flutter, but I'd appreciate any thoughts from @rinukkusu and @roisnir on how to better explain the Authorization Code Flow for a Dart app.