### PR TITLE
Fix web compilation issues

### DIFF
--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -5,11 +5,6 @@ library spotify;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
-
-import 'dart:io' // Default
-    if (dart.library.io) 'dart:io'
-    if (dart.library.html) 'dart:html';
 
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
@@ -33,4 +28,3 @@ part 'src/spotify_credentials.dart';
 part 'src/spotify_base.dart';
 part 'src/spotify_exception.dart';
 part 'src/spotify.dart';
-part 'src/spotify_mock.dart';

--- a/lib/src/spotify_mock.dart
+++ b/lib/src/spotify_mock.dart
@@ -1,4 +1,9 @@
-part of spotify;
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:spotify/spotify.dart';
+import 'package:http/http.dart' as http;
+import 'package:oauth2/oauth2.dart' as oauth2;
 
 class SpotifyApiMock extends SpotifyApiBase {
   SpotifyApiMock(SpotifyApiCredentials credentials)

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:spotify/src/spotify_mock.dart';
 import 'package:test/test.dart';
 import 'package:spotify/spotify.dart';
 


### PR DESCRIPTION
This PR will fix https://github.com/rinukkusu/spotify-dart/issues/42, an issue that was introduced with https://github.com/rinukkusu/spotify-dart/pull/34 (my bad).

I'm making two assumptions with these changes, please call me out if either are incorrect:
* There's no real reason that we need `spotify_mock.dart` to be part of the `spotify` library
* We don't actually need to import `dart:io` or `dart:html` in order for [`http.Client()` to know which type  of client to create](https://github.com/dart-lang/http/blob/master/lib/src/client.dart#L31-L35); it just detects which library is _available_, not which library is imported

Testing looks good run from running unit tests and debugging in a Flutter app. However, I haven't directly tested these changes against a web app yet, which is why this is marked as a draft. 😃 