### PR TITLE
Move 'me' related calls to own endpoint class

### DIFF
--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -24,6 +24,7 @@ part 'src/endpoints/users.dart';
 part 'src/endpoints/search.dart';
 part 'src/endpoints/audio_features.dart';
 part 'src/endpoints/categories.dart';
+part 'src/endpoints/me.dart';
 
 part 'src/spotify_credentials.dart';
 part 'src/spotify_base.dart';

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2019, chances, rinukkusu. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+part of spotify;
+
+class Me extends EndpointPaging {
+  @override
+  String get _path => 'v1/me';
+
+  Me(SpotifyApiBase api) : super(api);
+
+  Future<User> get() async {
+    var jsonString = await _api._get(_path);
+    var map = json.decode(jsonString);
+
+    return User.fromJson(map);
+  }
+
+  Future<Player> currentlyPlaying() async {
+    var jsonString = await _api._get('$_path/player/currently-playing');
+
+    if (jsonString.isEmpty) {
+      return Player();
+    }
+
+    var map = json.decode(jsonString);
+    return Player.fromJson(map);
+  }
+
+  Future<Iterable<Track>> recentlyPlayed() async {
+    var jsonString = await _api._get('$_path/player/recently-played');
+    var map = json.decode(jsonString);
+
+    var items = map['items'] as Iterable<dynamic>;
+    return items.map((item) => Track.fromJson(item['track']));
+  }
+
+  Future<Iterable<Track>> topTracks() async {
+    var jsonString = await _api._get('$_path/top/tracks');
+    var map = json.decode(jsonString);
+
+    var items = map['items'] as Iterable<dynamic>;
+    return items.map((item) => Track.fromJson(item));
+  }
+
+  Future<Iterable<Device>> devices() async {
+    return _api._get('$_path/player/devices').then(_parseDeviceJson);
+  }
+
+  Iterable<Device> _parseDeviceJson(String jsonString) {
+    var map = json.decode(jsonString);
+
+    var items = map['devices'] as Iterable<dynamic>;
+    return items.map((item) => Device.fromJson(item));
+  }
+}

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -7,52 +7,26 @@ class Users extends EndpointPaging {
   @override
   String get _path => 'v1/users';
 
-  Users(SpotifyApiBase api) : super(api);
+  Me _me;
 
-  Future<User> me() async {
-    var jsonString = await _api._get('v1/me');
-    var map = json.decode(jsonString);
-
-    return User.fromJson(map);
+  Users(SpotifyApiBase api, Me me) : super(api){ 
+    _me = me;
   }
 
-  Future<Player> currentlyPlaying() async {
-    var jsonString = await _api._get('v1/me/player/currently-playing');
+  @Deprecated('Use "SpotifyApi.me.get()"')
+  Future<User> me() => _me.get();
 
-    if (jsonString.isEmpty) {
-      return Player();
-    }
+  @Deprecated('Use "SpotifyApi.me.currentlyPlaying()"')
+  Future<Player> currentlyPlaying() => _me.currentlyPlaying();
 
-    var map = json.decode(jsonString);
-    return Player.fromJson(map);
-  }
+  @Deprecated('Use "SpotifyApi.me.recentlyPlayed()"')
+  Future<Iterable<Track>> recentlyPlayed() => _me.recentlyPlayed();
 
-  Future<Iterable<Track>> recentlyPlayed() async {
-    var jsonString = await _api._get('v1/me/player/recently-played');
-    var map = json.decode(jsonString);
+  @Deprecated('Use "SpotifyApi.me.topTracks()"')
+  Future<Iterable<Track>> topTracks() => _me.topTracks();
 
-    var items = map['items'] as Iterable<dynamic>;
-    return items.map((item) => Track.fromJson(item['track']));
-  }
-
-  Future<Iterable<Track>> topTracks() async {
-    var jsonString = await _api._get('v1/me/top/tracks');
-    var map = json.decode(jsonString);
-
-    var items = map['items'] as Iterable<dynamic>;
-    return items.map((item) => Track.fromJson(item));
-  }
-
-  Future<Iterable<Device>> devices() async {
-    return _api._get('v1/me/player/devices').then(_parseDeviceJson);
-  }
-
-  Iterable<Device> _parseDeviceJson(String jsonString) {
-    var map = json.decode(jsonString);
-
-    var items = map['devices'] as Iterable<dynamic>;
-    return items.map((item) => Device.fromJson(item));
-  }
+  @Deprecated('Use "SpotifyApi.me.devices()"')
+  Future<Iterable<Device>> devices() async => _me.devices();
 
   Future<UserPublic> get(String userId) async {
     var jsonString = await _api._get('$_path/$userId');

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -10,41 +10,47 @@ abstract class SpotifyApiBase {
       'https://accounts.spotify.com/authorize';
 
   FutureOr<oauth2.Client> _client;
-  Artists _artists;
-  Albums _albums;
-  Tracks _tracks;
-  Playlists _playlists;
-  RecommendationsEndpoint _recommendations;
-  Users _users;
-  Search _search;
-  AudioFeatures _audioFeatures;
-  Categories _categories;
 
+  Artists _artists;
   Artists get artists => _artists;
 
+  Albums _albums;
   Albums get albums => _albums;
 
+  Tracks _tracks;
   Tracks get tracks => _tracks;
 
+  Playlists _playlists;
   Playlists get playlists => _playlists;
 
+  RecommendationsEndpoint _recommendations;
   RecommendationsEndpoint get recommendations => _recommendations;
 
+  Users _users;
   Users get users => _users;
 
+  Search _search;
   Search get search => _search;
 
+  AudioFeatures _audioFeatures;
   AudioFeatures get audioFeatures => _audioFeatures;
+
+  Categories _categories;
   Categories get categories => _categories;
+
+  Me _me;
+  Me get me => _me; 
 
   SpotifyApiBase.fromClient(FutureOr<http.BaseClient> client) {
     _client = client;
+
     _artists = Artists(this);
     _albums = Albums(this);
     _tracks = Tracks(this);
     _playlists = Playlists(this);
     _recommendations = RecommendationsEndpoint(this);
-    _users = Users(this);
+    _me = Me(this);
+    _users = Users(this, _me);
     _search = Search(this);
     _audioFeatures = AudioFeatures(this);
     _categories = Categories(this);


### PR DESCRIPTION
I found the mix in the `Users` endpoint class a little confusing and decided to pull out all `me` related calls to its own endpoint class.