### PR TITLE
Search: add market parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3
+
+- search: add market parameter
+
 ## 0.3.2
 
 - users: move `me` calls to own endpoint class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.3
 
 - search: add market parameter
+- add request rate handling with retries
 
 ## 0.3.2
 

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -9,10 +9,27 @@ class Search extends EndpointPaging {
 
   Search(SpotifyApiBase api) : super(api);
 
+  /// Get Spotify Catalog information about albums, artists, playlists, 
+  /// tracks, shows or episodes that match a keyword string.
+  /// 
+  /// [market]: An ISO 3166-1 alpha-2 country code or the string 'from_token'.
+  /// If a country code is specified, only artists, albums, and tracks with 
+  /// content that is playable in that market is returned. 
   BundledPages get(String searchQuery,
-      [Iterable<SearchType> types = SearchType.all]) {
+      [Iterable<SearchType> types = SearchType.all, String market = '']) {
     var type = types.map((type) => type.key).join(',');
-    return _getBundledPages('$_path?q=$searchQuery&type=${type}', {
+
+    var queryMap = {
+      'q': searchQuery,
+      'type': type
+    };
+    if (market?.isNotEmpty == true) {
+      queryMap.addAll({'market': market});
+    }
+
+    var query = _buildQuery(queryMap);
+
+    return _getBundledPages('$_path?$query', {
       'playlists': (json) => PlaylistSimple.fromJson(json),
       'albums': (json) => AlbumSimple.fromJson(json),
       'artists': (json) => Artist.fromJson(json),

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -23,7 +23,7 @@ class Search extends EndpointPaging {
       'q': searchQuery,
       'type': type
     };
-    if (market?.isNotEmpty == true) {
+    if (market.isNotEmpty) {
       queryMap.addAll({'market': market});
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spotify
 description: An incomplete dart library for interfacing with the Spotify Web API.
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/rinukkusu/spotify-dart
 
 environment:


### PR DESCRIPTION
This PR adds the parameter `market` to the search endpoint to be able to specifiy for which market to return search results.