### PR TITLE
Add /me/following endpoint

### DIFF
--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -16,6 +16,31 @@ class Me extends EndpointPaging {
     return User.fromJson(map);
   }
 
+  /// Endpoint /v1/me/following only supports "artist" type at the moment.
+  /// Unknown what other types will be supported in the future.
+  Future<Iterable<Artist>> following({int limit = 20, String after}) async {
+    assert(limit >= 1 && limit <= 50, 'limit should be 1 <= limit <= 50');
+    var params = <String, String>{
+      'type': 'artist',
+      'limit': limit.toString(),
+    };
+    if (after != null) {
+      params['after'] = after;
+    }
+
+    var path =
+        Uri(path: '$_path/following', queryParameters: params).toString();
+    var map = json.decode(await _api._get(path));
+
+    var artistsMap = map['artists'] as Map<String, dynamic>;
+    if (!artistsMap.containsKey('items')) {
+      return [];
+    }
+
+    var itemsMap = artistsMap['items'] as Iterable<dynamic>;
+    return itemsMap.map((m) => Artist.fromJson(m));
+  }
+
   Future<Player> currentlyPlaying() async {
     var jsonString = await _api._get('$_path/player/currently-playing');
 

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -17,28 +17,10 @@ class Me extends EndpointPaging {
   }
 
   /// Endpoint /v1/me/following only supports "artist" type at the moment.
-  /// Unknown what other types will be supported in the future.
-  Future<Iterable<Artist>> following({int limit = 20, String after}) async {
-    assert(limit >= 1 && limit <= 50, 'limit should be 1 <= limit <= 50');
-    var params = <String, String>{
-      'type': 'artist',
-      'limit': limit.toString(),
-    };
-    if (after != null) {
-      params['after'] = after;
-    }
-
-    var path =
-        Uri(path: '$_path/following', queryParameters: params).toString();
-    var map = json.decode(await _api._get(path));
-
-    var artistsMap = map['artists'] as Map<String, dynamic>;
-    if (!artistsMap.containsKey('items')) {
-      return [];
-    }
-
-    var itemsMap = artistsMap['items'] as Iterable<dynamic>;
-    return itemsMap.map((m) => Artist.fromJson(m));
+  BundledPages following(FollowingType type) {
+    return _getBundledPages('$_path/following?type=${type.key}', {
+      'artists': (json) => Artist.fromJson(json),
+    });
   }
 
   Future<Player> currentlyPlaying() async {
@@ -78,4 +60,13 @@ class Me extends EndpointPaging {
     var items = map['devices'] as Iterable<dynamic>;
     return items.map((item) => Device.fromJson(item));
   }
+}
+
+class FollowingType {
+  final String _key;
+
+  const FollowingType(this._key);
+  String get key => _key;
+
+  static const artist = FollowingType('artist');
 }


### PR DESCRIPTION
Had a use case to fetch a user's following artists. Seems like the `/v1/me/following` endpoint requires a `type` param, which only supports `artist` right now ([doc here](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/)), so I kind of made the function specifically return artists right now. Open to generalizing/renaming function if needed.
