### PR TITLE
Saved Credentials Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ final spotify = SpotifyApi.fromAuthCodeGrant(grant, responseUri);
 </details>
 
 #### Saved Credentials Flow
-No one wants to redo the Authorization Code Flow for every login or app start. If you save your credentials somewhere while authenticated, you can reconnect to Spotify later by passing those credentials into the constructor. If the access token is expired at this point, the credentials will be automatically refreshed.
+No one wants to redo the Authorization Code Flow for every login or app start. If you save your credentials somewhere while authenticated, you can reconnect to Spotify later by passing those credentials into the constructor. If the access token is expired at this point, the credentials will be automatically refreshed. If the refresh token has been revoked for any reason, an exception will be thrown and you'll need to reauthenticate through another flow.
 
 ```dart
 // Connect to Spotify using the Authorization Code Flow

--- a/README.md
+++ b/README.md
@@ -7,14 +7,9 @@ A dart library for interfacing with the Spotify API.
 ### Simple Example
 
 ```dart
-import 'package:spotify/spotify.dart';
-
-void main() async {
-  var credentials = SpotifyApiCredentials(clientId, clientSecret);
-  var spotify = SpotifyApi(credentials);
-
-  var artist = await spotify.artists.get('0OdUWJ0sBjDrqHygGUXeCF');
-}
+final credentials = SpotifyApiCredentials(clientId, clientSecret);
+final spotify = SpotifyApi(credentials);
+final artist = await spotify.artists.get('0OdUWJ0sBjDrqHygGUXeCF');
 ```
 
 ### Authorization
@@ -22,49 +17,45 @@ void main() async {
 This flow is recommended when you only need access to public Spotify data. It cannot be used to access or manage a user's private data.
 
 ```dart
-SpotifyApi getSpotifyApi() {
-  final credentials = SpotifyApiCredentials(clientId, clientSecret);
-  return SpotifyApi(credentials);
-}
+final credentials = SpotifyApiCredentials(clientId, clientSecret);
+final spotify = SpotifyApi(credentials);
 ```
 
 #### Authorization Code Flow
 This flow is suitable for long-running applications when you need to access or manage a user's private data. The Authorization Code Flow is a complex process, so it's highly recommended to read through [Spotify's Authorization Guide][spotify_auth] before attempting. Note that this package simplifies the creation of the authorization URI and the process of requesting tokens after receiving an authorization code.
 
 ```dart
-SpotifyApi getSpotifyApi() async {
-  final credentials = SpotifyApiCredentials(clientId, clientSecret);
-  final grant = SpotifyApi.authorizationCodeGrant(credentials);
+final credentials = SpotifyApiCredentials(clientId, clientSecret);
+final grant = SpotifyApi.authorizationCodeGrant(credentials);
 
-  // The URI to redirect to after the user grants or denies permission. It must
-  // be in your Spotify application's Redirect URI whitelist. This URI can
-  // either be a web address pointing to an authorization server or a fabricated
-  // URI that allows the client device to function as an authorization server.
-  final redirectUri = 'https://example.com/auth';
+// The URI to redirect to after the user grants or denies permission. It must
+// be in your Spotify application's Redirect URI whitelist. This URI can
+// either be a web address pointing to an authorization server or a fabricated
+// URI that allows the client device to function as an authorization server.
+final redirectUri = 'https://example.com/auth';
 
-  // See https://developer.spotify.com/documentation/general/guides/scopes/
-  // for a complete list of these Spotify authorization permissions. If no
-  // scopes are specified, only public Spotify information will be available.
-  final scopes = ['user-read-email', 'user-library-read'];
+// See https://developer.spotify.com/documentation/general/guides/scopes/
+// for a complete list of these Spotify authorization permissions. If no
+// scopes are specified, only public Spotify information will be available.
+final scopes = ['user-read-email', 'user-library-read'];
 
-  var authUri = grant.getAuthorizationUrl(
-    Uri.parse(redirectUri),
-    scopes: scopes, // scopes are optional
-  );
+final authUri = grant.getAuthorizationUrl(
+  Uri.parse(redirectUri),
+  scopes: scopes, // scopes are optional
+);
 
-  // `redirect` is an imaginary function that redirects the resource owner's
-  // browser to the `authUri` on the authorization server. Once the resource
-  // owner has authorized, they'll be redirected to the `redirectUri` with an
-  // authorization code. The exact implementation varies across platforms.
-  await redirect(authUri);
+// `redirect` is an imaginary function that redirects the resource owner's
+// browser to the `authUri` on the authorization server. Once the resource
+// owner has authorized, they'll be redirected to the `redirectUri` with an
+// authorization code. The exact implementation varies across platforms.
+await redirect(authUri);
 
-  // `listen` is another imaginary function that listens for a request to
-  // `redirectUri` after the user grants or denies permission. Again, the
-  // exact implementation varies across platforms.
-  final responseUri = await listen(redirectUri);
+// `listen` is another imaginary function that listens for a request to
+// `redirectUri` after the user grants or denies permission. Again, the
+// exact implementation varies across platforms.
+final responseUri = await listen(redirectUri);
 
-  return SpotifyApi.fromAuthCodeGrant(grant, responseUri);
-}
+final spotify = SpotifyApi.fromAuthCodeGrant(grant, responseUri);
 ```
 
 <details>
@@ -77,38 +68,67 @@ SpotifyApi getSpotifyApi() async {
   For Flutter apps, there's two popular approaches:
   1. Launch a browser using [url_launcher][] and listen for a redirect using [uni_links][].
       ```dart
-        if (await canLaunch(authUri)) {
-          await launch(authUri);
-        }
+      if (await canLaunch(authUri)) {
+        await launch(authUri);
+      }
 
-        ...
-    
-        final linksStream = getLinksStream().listen((String link) async {
-          if (link.startsWith(redirectUri)) {
-            responseUri = link;
-          }
-        });
+      ...
+  
+      final linksStream = getLinksStream().listen((String link) async {
+        if (link.startsWith(redirectUri)) {
+          responseUri = link;
+        }
+      });
       ```
 
   2. Launch a WebView inside the app and listen for a redirect using [webview_flutter][].
       ```dart
-        WebView(
-          javascriptMode: JavascriptMode.unrestricted,
-          initialUrl: authUri,
-          navigationDelegate: (navReq) {
-            if (navReq.url.startsWith(redirectUri)) {
-              responseUri = navReq.url;
-              return NavigationDecision.prevent;
-            }
-            
-            return NavigationDecision.navigate;
-          },
-          ...
-        );
+      WebView(
+        javascriptMode: JavascriptMode.unrestricted,
+        initialUrl: authUri,
+        navigationDelegate: (navReq) {
+          if (navReq.url.startsWith(redirectUri)) {
+            responseUri = navReq.url;
+            return NavigationDecision.prevent;
+          }
+          
+          return NavigationDecision.navigate;
+        },
+        ...
+      );
       ```
    
   For Dart apps, the best approach depends on the available options for accessing a browser. In general, you'll need to launch the authorization URI through the client's browser and listen for the redirect URI.
 </details>
+
+#### Saved Credentials Flow
+No one wants to redo the Authorization Code Flow for every login or app start. If you save your credentials somewhere while authenticated, you can reconnect to Spotify later by passing those credentials into the constructor. If the access token is expired at this point, the credentials will be automatically refreshed.
+
+```dart
+// Connect to Spotify using the Authorization Code Flow
+final spotify = SpotifyApi(...);
+
+// Save the credentials somewhere (local storage, database etc.)
+someService.saveCredentials(spotify.getCredentials());
+
+...
+
+// Retrieve the saved credentials and use them to connect to Spotify
+final credentials = someService.retrieveCredentials();
+
+// All of these fields are required for the Saved Credentials Flow
+final spotifyCredentials = SpotifyApiCredentials(
+    credentials.clientId,
+    credentials.clientSecret,
+    accessToken: credentials.accessToken,
+    refreshToken: credentials.refreshToken,
+    tokenEndpoint: credentials.tokenEndpoint,
+    scopes: credentials.scopes,
+    expiration: credentials.expiration,
+  );
+
+final spotify = SpotifyApi(spotifyCredentials);
+```
 
 ## Features and bugs
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ final spotifyCredentials = SpotifyApiCredentials(
     credentials.clientSecret,
     accessToken: credentials.accessToken,
     refreshToken: credentials.refreshToken,
-    tokenEndpoint: credentials.tokenEndpoint,
     scopes: credentials.scopes,
     expiration: credentials.expiration,
   );

--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -47,7 +47,7 @@ Future<SpotifyApi> _getUserAuthenticatedSpotifyApi(
 }
 
 void _currentlyPlaying(SpotifyApi spotify) async =>
-    await spotify.users.currentlyPlaying().then((a) {
+    await spotify.me.currentlyPlaying().then((a) {
       if (a == null) {
         print('Nothing currently playing.');
         return;
@@ -56,7 +56,7 @@ void _currentlyPlaying(SpotifyApi spotify) async =>
     }).catchError(_prettyPrintError);
 
 void _devices(SpotifyApi spotify) async =>
-    await spotify.users.devices().then((devices) {
+    await spotify.me.devices().then((devices) {
       if (devices == null) {
         print('No devices currently playing.');
         return;

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -87,9 +87,12 @@ abstract class SpotifyApiBase {
       );
     }
 
-    return oauth2.clientCredentialsGrant(Uri.parse(SpotifyApiBase._tokenUrl),
-        credentials.clientId, credentials.clientSecret,
-        httpClient: httpClient);
+    return oauth2.clientCredentialsGrant(
+      Uri.parse(SpotifyApiBase._tokenUrl),
+      credentials.clientId,
+      credentials.clientSecret,
+      httpClient: httpClient,
+    );
   }
 
   Future<String> _get(String path) {

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -50,7 +50,7 @@ abstract class SpotifyApiBase {
 
   SpotifyApiBase(SpotifyApiCredentials credentials,
       [http.BaseClient httpClient])
-      : this.fromClient(_getClient(credentials, httpClient));
+      : this.fromClient(_getOauth2Client(credentials, httpClient));
 
   SpotifyApiBase.fromAuthCodeGrant(
       oauth2.AuthorizationCodeGrant grant, String responseUri)
@@ -67,7 +67,7 @@ abstract class SpotifyApiBase {
         httpClient: httpClient);
   }
 
-  static FutureOr<oauth2.Client> _getClient(
+  static FutureOr<oauth2.Client> _getOauth2Client(
       SpotifyApiCredentials credentials, http.BaseClient httpClient) async {
     if (credentials.fullyQualified) {
       var oauthCredentials = credentials._toOauth2Credentials();

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -68,16 +68,26 @@ abstract class SpotifyApiBase {
   }
 
   static FutureOr<oauth2.Client> _getClient(
-      SpotifyApiCredentials credentials, http.BaseClient httpClient) {
+      SpotifyApiCredentials credentials, http.BaseClient httpClient) async {
     if (credentials.fullyQualified) {
+      var oauthCredentials = oauth2.Credentials(
+        credentials.accessToken,
+        refreshToken: credentials.refreshToken,
+        tokenEndpoint: credentials.tokenEndpoint,
+        scopes: credentials.scopes,
+        expiration: credentials.expiration,
+      );
+
+      if (oauthCredentials.isExpired) {
+        oauthCredentials = await oauthCredentials.refresh(
+          identifier: credentials.clientId,
+          secret: credentials.clientSecret,
+          httpClient: httpClient,
+        );
+      }
+
       return oauth2.Client(
-        oauth2.Credentials(
-          credentials.accessToken,
-          refreshToken: credentials.refreshToken,
-          tokenEndpoint: credentials.tokenEndpoint,
-          scopes: credentials.scopes,
-          expiration: credentials.expiration,
-        ),
+        oauthCredentials,
         identifier: credentials.clientId,
         secret: credentials.clientSecret,
       );

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -70,13 +70,7 @@ abstract class SpotifyApiBase {
   static FutureOr<oauth2.Client> _getClient(
       SpotifyApiCredentials credentials, http.BaseClient httpClient) async {
     if (credentials.fullyQualified) {
-      var oauthCredentials = oauth2.Credentials(
-        credentials.accessToken,
-        refreshToken: credentials.refreshToken,
-        tokenEndpoint: credentials.tokenEndpoint,
-        scopes: credentials.scopes,
-        expiration: credentials.expiration,
-      );
+      var oauthCredentials = credentials._toOauth2Credentials();
 
       if (oauthCredentials.isExpired) {
         oauthCredentials = await oauthCredentials.refresh(

--- a/lib/src/spotify_credentials.dart
+++ b/lib/src/spotify_credentials.dart
@@ -42,7 +42,15 @@ class SpotifyApiCredentials {
   /// expiration date.
   DateTime expiration;
 
-  SpotifyApiCredentials(this.clientId, this.clientSecret);
+  SpotifyApiCredentials(
+    this.clientId,
+    this.clientSecret, {
+    this.accessToken,
+    this.refreshToken,
+    this.tokenEndpoint,
+    this.scopes,
+    this.expiration,
+  });
 
   SpotifyApiCredentials._fromClient(oauth2.Client client) {
     clientId = client.identifier;
@@ -69,4 +77,15 @@ class SpotifyApiCredentials {
   bool get canRefresh => refreshToken != null && tokenEndpoint != null;
 
   String get basicAuth => base64.encode('$clientId:$clientSecret'.codeUnits);
+
+  /// Whether or not these credentials contain all of the required information
+  /// to generate a client with access to a user's private data.
+  bool get fullyQualified =>
+      clientId != null &&
+      clientSecret != null &&
+      accessToken != null &&
+      refreshToken != null &&
+      tokenEndpoint != null &&
+      scopes != null &&
+      expiration != null;
 }

--- a/lib/src/spotify_credentials.dart
+++ b/lib/src/spotify_credentials.dart
@@ -78,7 +78,7 @@ class SpotifyApiCredentials {
   String get basicAuth => base64.encode('$clientId:$clientSecret'.codeUnits);
 
   /// Whether or not these credentials contain all of the required information
-  /// to generate a client with access to a user's private data.
+  /// to create a client with access to a user's private data.
   bool get fullyQualified =>
       clientId != null &&
       clientSecret != null &&

--- a/lib/src/spotify_credentials.dart
+++ b/lib/src/spotify_credentials.dart
@@ -47,10 +47,9 @@ class SpotifyApiCredentials {
     this.clientSecret, {
     this.accessToken,
     this.refreshToken,
-    this.tokenEndpoint,
     this.scopes,
     this.expiration,
-  });
+  }) : tokenEndpoint = Uri.parse(SpotifyApiBase._tokenUrl);
 
   SpotifyApiCredentials._fromClient(oauth2.Client client) {
     clientId = client.identifier;
@@ -88,4 +87,12 @@ class SpotifyApiCredentials {
       tokenEndpoint != null &&
       scopes != null &&
       expiration != null;
+
+  oauth2.Credentials _toOauth2Credentials() => oauth2.Credentials(
+        accessToken,
+        refreshToken: refreshToken,
+        tokenEndpoint: tokenEndpoint,
+        scopes: scopes,
+        expiration: expiration,
+      );
 }

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -81,13 +81,13 @@ Future main() async {
 
   group('User', () {
     test('currentlyPlaying', () async {
-      var result = await spotify.users.currentlyPlaying();
+      var result = await spotify.me.currentlyPlaying();
 
       expect(result.item.name, 'So Voce');
     });
 
     test('devices', () async {
-      var result = await spotify.users.devices();
+      var result = await spotify.me.devices();
       expect(result.length, 1);
       expect(result.first.id, '5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e');
       expect(result.first.isActive, true);
@@ -114,22 +114,23 @@ Future main() async {
       expect(result.isExpired, true);
     });
   });
-  group('Errors', (){
+  group('Errors', () {
     test('apiRateErrorSuccess', () async {
-      spotify.mockHttpErrors = List.generate(4,
-              (i)=>MockHttpError(
-                  statusCode: 429,
-                  message: 'API Rate exceeded',
-                  headers: {'retry-after': '1'})).iterator;
-      ApiRateException ex;
+      spotify.mockHttpErrors = List.generate(
+          4,
+          (i) => MockHttpError(
+              statusCode: 429,
+              message: 'API Rate exceeded',
+              headers: {'retry-after': '1'})).iterator;
       var artist = await spotify.artists.get('0TnOYISbd1XYRBk9myaseg');
       expect(artist.type, 'artist');
       expect(artist.id, '0TnOYISbd1XYRBk9myaseg');
       expect(artist.images.length, 3);
     });
-  test('apiRateErrorFail', () async {
-      spotify.mockHttpErrors = List.generate(10,
-              (i)=>MockHttpError(
+    test('apiRateErrorFail', () async {
+      spotify.mockHttpErrors = List.generate(
+          10,
+          (i) => MockHttpError(
               statusCode: 429,
               message: 'API Rate exceeded',
               headers: {'retry-after': '1'})).iterator;


### PR DESCRIPTION
Changes:
* Support creating Spotify API from saved credentials, based off https://github.com/rinukkusu/spotify-dart/issues/32#issuecomment-619038947
* Simplify construction of a fully qualified `SpotifyApiCredentials` object
* Update README with directions on how to authenticate with saved credentials