### PR TITLE
Add release date to AlbumSimple

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -92,6 +92,8 @@ void main() async {
             'artists: ${item.artists.length}\n'
             'availableMarkets: ${item.availableMarkets.length}\n'
             'images: ${item.images.length}\n'
+            'releaseDate: ${item.releaseDate}\n'
+            'releaseDatePrecision: ${item.releaseDatePrecision}\n'
             '-------------------------------');
       }
     });

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -71,6 +71,8 @@ AlbumSimple _$AlbumSimpleFromJson(Map<String, dynamic> json) {
             (e) => e == null ? null : Image.fromJson(e as Map<String, dynamic>))
         ?.toList()
     ..name = json['name'] as String
+    ..releaseDate = json['release_date'] as String
+    ..releaseDatePrecision = json['release_date_precision'] as String
     ..type = json['type'] as String
     ..uri = json['uri'] as String;
 }

--- a/lib/src/models/album.dart
+++ b/lib/src/models/album.dart
@@ -79,6 +79,16 @@ class AlbumSimple extends Object {
   /// empty string.
   String name;
 
+  /// The date the album was first released, for example "1981-12-15".
+  /// Depending on the precision, it might be shown as "1981" or "1981-12".
+  @JsonKey(name: 'release_date')
+  String releaseDate;
+
+  /// The precision with which release_date value is known:
+  ///     "year", "month", or "day".
+  @JsonKey(name: 'release_date_precision')
+  String releaseDatePrecision;
+
   /// The object type: "album"
   String type;
 


### PR DESCRIPTION
This PR adds `release_date` and `release_date_precision` to `AlbumSimple`.
Also prints these fields in the example to verify they are present.

Fixes #63