### PR TITLE
Improved me.recentlyPlayed() (fixes #30)

### DIFF
--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -36,20 +36,17 @@ class Me extends EndpointPaging {
 
   Future<Iterable<PlayHistory>> recentlyPlayed(
       {int limit, DateTime after, DateTime before}) async {
-    if (after != null && before != null) {
-      throw Exception('Cannot specify both after and before.');
-    }
+    assert(after == null || before == null,
+        'Cannot specify both after and before.');
 
-    var jsonString = await _api._get('$_path/player/recently-played?' +
+    final jsonString = await _api._get('$_path/player/recently-played?' +
         _buildQuery({
           'limit': limit,
           'after': after?.millisecondsSinceEpoch,
           'before': before?.millisecondsSinceEpoch
         }));
-    var map = json.decode(jsonString);
-
-    var items = map['items'] as Iterable<dynamic>;
-    return items.map((item) => PlayHistory.fromJson(item));
+    final map = json.decode(jsonString);
+    return map['items'].map((item) => PlayHistory.fromJson(item));
   }
 
   Future<Iterable<Track>> topTracks() async {
@@ -76,6 +73,7 @@ class FollowingType {
   final String _key;
 
   const FollowingType(this._key);
+
   String get key => _key;
 
   static const artist = FollowingType('artist');

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -34,12 +34,22 @@ class Me extends EndpointPaging {
     return Player.fromJson(map);
   }
 
-  Future<Iterable<Track>> recentlyPlayed() async {
-    var jsonString = await _api._get('$_path/player/recently-played');
+  Future<Iterable<PlayHistory>> recentlyPlayed(
+      {int limit, DateTime after, DateTime before}) async {
+    if (after != null && before != null) {
+      throw Exception('Cannot specify both after and before.');
+    }
+
+    var jsonString = await _api._get('$_path/player/recently-played?' +
+        _buildQuery({
+          'limit': limit,
+          'after': after?.millisecondsSinceEpoch,
+          'before': before?.millisecondsSinceEpoch
+        }));
     var map = json.decode(jsonString);
 
     var items = map['items'] as Iterable<dynamic>;
-    return items.map((item) => Track.fromJson(item['track']));
+    return items.map((item) => PlayHistory.fromJson(item));
   }
 
   Future<Iterable<Track>> topTracks() async {

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -20,7 +20,7 @@ class Users extends EndpointPaging {
   Future<Player> currentlyPlaying() => _me.currentlyPlaying();
 
   @Deprecated('Use "SpotifyApi.me.recentlyPlayed()"')
-  Future<Iterable<Track>> recentlyPlayed() => _me.recentlyPlayed();
+  Future<Iterable<PlayHistory>> recentlyPlayed() => _me.recentlyPlayed();
 
   @Deprecated('Use "SpotifyApi.me.topTracks()"')
   Future<Iterable<Track>> topTracks() => _me.topTracks();

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -480,3 +480,16 @@ UserPublic _$UserPublicFromJson(Map<String, dynamic> json) {
     ..type = json['type'] as String
     ..uri = json['uri'] as String;
 }
+
+PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) {
+  return PlayHistory()
+    ..track = json['track'] == null
+        ? null
+        : TrackSimple.fromJson(json['track'] as Map<String, dynamic>)
+    ..playedAt = json['played_at'] == null
+        ? null
+        : DateTime.parse(json['played_at'] as String)
+    ..context = json['context'] == null
+        ? null
+        : PlayerContext.fromJson(json['context'] as Map<String, dynamic>);
+}

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -102,3 +102,20 @@ class UserPublic extends Object {
   /// The Spotify URI for this user.
   String uri;
 }
+
+@JsonSerializable(createToJson: false)
+class PlayHistory extends Object {
+  PlayHistory();
+  factory PlayHistory.fromJson(Map<String, dynamic> json) =>
+      _$PlayHistoryFromJson(json);
+
+  /// The track the user listened to.
+  TrackSimple track;
+
+  /// The date and time the track was played.
+  @JsonKey(name: 'played_at')
+  DateTime playedAt;
+
+  /// The context the track was played from.
+  PlayerContext context;
+}


### PR DESCRIPTION
The `me.recentlyPlayed()` function now supports the `limit`, `before`, and `after` parameters that Spotify supports, and it returns `PlayHistory` objects, which retain the `playedAt` and `context` values.