### PR TITLE
Unit test for the recently-played endpoint

### DIFF
--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -46,7 +46,7 @@ class Me extends EndpointPaging {
           'before': before?.millisecondsSinceEpoch
         }));
     final map = json.decode(jsonString);
-    return map['items'].map((item) => PlayHistory.fromJson(item));
+    return map['items'].map<PlayHistory>((item) => PlayHistory.fromJson(item));
   }
 
   Future<Iterable<Track>> topTracks() async {

--- a/test/data/v1/me/player/recently.json
+++ b/test/data/v1/me/player/recently.json
@@ -1,0 +1,97 @@
+{
+    "items": [
+      {
+        "track": {
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+              },
+              "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+              "id": "5INjqkS1o8h1imAzPqGZBb",
+              "name": "Tame Impala",
+              "type": "artist",
+              "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+            }
+          ],
+          "available_markets": [
+            "CA",
+            "MX",
+            "US"
+          ],
+          "disc_number": 1,
+          "duration_ms": 108546,
+          "explicit": false,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2gNfxysfBRfl9Lvi9T3v6R"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2gNfxysfBRfl9Lvi9T3v6R",
+          "id": "2gNfxysfBRfl9Lvi9T3v6R",
+          "name": "Disciples",
+          "preview_url": "https://p.scdn.co/mp3-preview/6023e5aac2123d098ce490488966b28838b14fa2",
+          "track_number": 9,
+          "type": "track",
+          "uri": "spotify:track:2gNfxysfBRfl9Lvi9T3v6R"
+        },
+        "played_at": "2016-12-13T20:44:04.589Z",
+        "context": {
+          "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb",
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+          },
+          "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+          "type": "artist"
+        }
+      },
+      {
+        "track": {
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+              },
+              "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+              "id": "5INjqkS1o8h1imAzPqGZBb",
+              "name": "Tame Impala",
+              "type": "artist",
+              "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+            }
+          ],
+          "available_markets": [
+            "CA",
+            "MX",
+            "US"
+          ],
+          "disc_number": 1,
+          "duration_ms": 467586,
+          "explicit": false,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/track/2X485T9Z5Ly0xyaghN73ed"
+          },
+          "href": "https://api.spotify.com/v1/tracks/2X485T9Z5Ly0xyaghN73ed",
+          "id": "2X485T9Z5Ly0xyaghN73ed",
+          "name": "Let It Happen",
+          "preview_url": "https://p.scdn.co/mp3-preview/05dee1ad0d2a6fa4ad07fbd24ae49d58468e8194",
+          "track_number": 1,
+          "type": "track",
+          "uri": "spotify:track:2X485T9Z5Ly0xyaghN73ed"
+        },
+        "played_at": "2016-12-13T20:42:17.016Z",
+        "context": {
+          "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb",
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+          },
+          "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+          "type": "artist"
+        }
+      }
+    ],
+    "next": "https://api.spotify.com/v1/me/player/recently-played?before=1481661737016&limit=2",
+    "cursors": {
+      "after": "1481661844589",
+      "before": "1481661737016"
+    },
+    "limit": 2,
+    "href": "https://api.spotify.com/v1/me/player/recently-played?limit=2"
+  }

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -97,6 +97,26 @@ Future main() async {
       expect(result.first.type, DeviceType.Computer);
       expect(result.first.volumePercent, 100);
     });
+
+    test('recentlyPlayed', () async {
+      // the parameters don't do anything. They are just dummies
+      var result = await spotify.me.recentlyPlayed(limit: 3, before: DateTime.now());
+      expect(result.length, 2);
+      var first = result.first;
+      expect(first.track != null, true);
+      
+      // just testing some sample attributes
+      var firstTrack = first.track;
+      expect(firstTrack.durationMs, 108546);
+      expect(firstTrack.explicit, false);
+      expect(firstTrack.id, '2gNfxysfBRfl9Lvi9T3v6R');
+      expect(firstTrack.artists.length, 1);
+      expect(firstTrack.artists.first.name, 'Tame Impala');
+
+      var second = result.last;
+      expect(second.playedAt, DateTime.tryParse('2016-12-13T20:42:17.016Z'));
+      expect(second.context.uri, 'spotify:artist:5INjqkS1o8h1imAzPqGZBb');
+    });
   });
 
   group('Auth', () {


### PR DESCRIPTION
This PR adds a unit test for the `recently-played` endpoint.

It also explicitly casts decoded json items to `PlayHistory`, which otherwise caused a runtime error.