### PR TITLE
Implemented credentials refresh callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ final spotifyCredentials = SpotifyApiCredentials(
 final spotify = SpotifyApi(spotifyCredentials);
 ```
 
+If, for any reason, you are planning to leave the app open in the background for a very long time and access Spotify's API with variable intervals, spotify-dart will automatically refresh the token if it's expired and updates you with the new credentials (in particular you need the new refresh token) by using the following methods.
+
+```dart
+final spotify = SpotifyApi.withCallback(spotifyCredentials, (SpotifyApiCredentials newCredentials) async {
+    await _saveCredentials(newCredentials); 
+); 
+```
+
+Where _saveCredentials is a method of your choice to save the credentials locally.
+
 ## Features and bugs
 
 Please file feature requests and bugs at the [issue tracker][tracker].

--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ someService.saveCredentials(spotify.getCredentials());
 If, for any reason, you are planning to leave the app open in the background for a very long time and access Spotify's API with variable intervals, spotify-dart will automatically refresh the token if it's expired and updates you with the new credentials (in particular you need the new refresh token) by using the following methods.
 
 ```dart
-final spotify = SpotifyApi.withCallback(spotifyCredentials, (SpotifyApiCredentials newCredentials) async {
-    someService.saveCredentials(newCredentials); 
-); 
+SpotifyApi api = SpotifyApi(spotifyCredentials, onCredentialsRefreshed: (SpotifyApiCredentials newCred) async {
+          await _saveCredentials(newCred);
+          print("Saved from oauth" + newCred.refreshToken);
+        });
 ``` 
 
 ## Features and bugs

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ final spotify = SpotifyApi.fromAuthCodeGrant(grant, responseUri);
 </details>
 
 #### Saved Credentials Flow
-No one wants to redo the Authorization Code Flow for every login or app start. If you save your credentials somewhere while authenticated, you can reconnect to Spotify later by passing those credentials into the constructor. If the access token is expired at this point, the credentials will be automatically refreshed. If the refresh token has been revoked for any reason, an exception will be thrown and you'll need to reauthenticate through another flow.
+No one wants to redo the Authorization Code Flow for every login or app start. If you save your credentials somewhere while authenticated, you can reconnect to Spotify later by passing those credentials into the constructor. If the access token is expired at this point, the credentials will be automatically refreshed. If the refresh token has been revoked for any reason, an exception will be thrown and you'll need to reauthenticate through another flow.  
 
 ```dart
 // Connect to Spotify using the Authorization Code Flow
@@ -127,6 +127,9 @@ final spotifyCredentials = SpotifyApiCredentials(
   );
 
 final spotify = SpotifyApi(spotifyCredentials);
+
+//The refresh token can be used to obtain just one access token. After token retrieval, a new refresh token is provided.
+someService.saveCredentials(spotify.getCredentials());
 ```
 
 If, for any reason, you are planning to leave the app open in the background for a very long time and access Spotify's API with variable intervals, spotify-dart will automatically refresh the token if it's expired and updates you with the new credentials (in particular you need the new refresh token) by using the following methods.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ final spotify = SpotifyApi.fromAuthCodeGrant(grant, responseUri);
 </details>
 
 #### Saved Credentials Flow
-No one wants to redo the Authorization Code Flow for every login or app start. If you save your credentials somewhere while authenticated, you can reconnect to Spotify later by passing those credentials into the constructor. If the access token is expired at this point, the credentials will be automatically refreshed. If the refresh token has been revoked for any reason, an exception will be thrown and you'll need to reauthenticate through another flow.  
+No one wants to redo the Authorization Code Flow for every login or app start. If you save your credentials somewhere while authenticated, you can reconnect to Spotify later by passing those credentials into the constructor. If the access token is expired at this point, the credentials will be automatically refreshed. If the refresh token has been revoked for any reason, an exception will be thrown and you'll need to reauthenticate through another flow.
 
 ```dart
 // Connect to Spotify using the Authorization Code Flow
@@ -136,11 +136,9 @@ If, for any reason, you are planning to leave the app open in the background for
 
 ```dart
 final spotify = SpotifyApi.withCallback(spotifyCredentials, (SpotifyApiCredentials newCredentials) async {
-    await _saveCredentials(newCredentials); 
+    someService.saveCredentials(newCredentials); 
 ); 
-```
-
-Where _saveCredentials is a method of your choice to save the credentials locally.
+``` 
 
 ## Features and bugs
 

--- a/lib/src/spotify.dart
+++ b/lib/src/spotify.dart
@@ -7,6 +7,9 @@ class SpotifyApi extends SpotifyApiBase {
   SpotifyApi(SpotifyApiCredentials credentials)
       : super(credentials, http.Client());
 
+  SpotifyApi.withRefreshCallback(SpotifyApiCredentials credentials, Function(SpotifyApiCredentials) callback)
+      : super(credentials, http.Client(), callback);
+
   SpotifyApi.fromClient(FutureOr<oauth2.Client> client)
       : super.fromClient(client);
 
@@ -17,5 +20,10 @@ class SpotifyApi extends SpotifyApiBase {
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
       SpotifyApiCredentials credentials) {
     return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client());
+  }
+
+  static oauth2.AuthorizationCodeGrant authorizationCodeGrantWithRefreshCallback(
+      SpotifyApiCredentials credentials, Function(SpotifyApiCredentials) callback) {
+    return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client(), callback);
   }
 }

--- a/lib/src/spotify.dart
+++ b/lib/src/spotify.dart
@@ -4,12 +4,9 @@
 part of spotify;
 
 class SpotifyApi extends SpotifyApiBase {
-  SpotifyApi(SpotifyApiCredentials credentials)
-      : super(credentials, http.Client());
-
-  SpotifyApi.withRefreshCallback(SpotifyApiCredentials credentials, Function(SpotifyApiCredentials) callback)
-      : super(credentials, http.Client(), callback);
-
+  SpotifyApi(SpotifyApiCredentials credentials, {Function(SpotifyApiCredentials) onCredentialsRefreshed})
+      : super(credentials, http.Client(), onCredentialsRefreshed);
+  
   SpotifyApi.fromClient(FutureOr<oauth2.Client> client)
       : super.fromClient(client);
 
@@ -18,12 +15,9 @@ class SpotifyApi extends SpotifyApiBase {
       : super.fromAuthCodeGrant(grant, responseUri);
 
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
-      SpotifyApiCredentials credentials) {
-    return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client());
+      SpotifyApiCredentials credentials, {Function(SpotifyApiCredentials) onCredentialsRefreshed}) {
+    return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client(), onCredentialsRefreshed);
   }
 
-  static oauth2.AuthorizationCodeGrant authorizationCodeGrantWithRefreshCallback(
-      SpotifyApiCredentials credentials, Function(SpotifyApiCredentials) callback) {
-    return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client(), callback);
-  }
+   
 }

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -6,8 +6,7 @@ part of spotify;
 abstract class SpotifyApiBase {
   static const String _baseUrl = 'https://api.spotify.com';
   static const String _tokenUrl = 'https://accounts.spotify.com/api/token';
-  static const String _authorizationUrl =
-      'https://accounts.spotify.com/authorize';
+  static const String _authorizationUrl = 'https://accounts.spotify.com/authorize';
 
   bool _shouldWait = false;
   FutureOr<oauth2.Client> _client;
@@ -51,27 +50,26 @@ abstract class SpotifyApiBase {
     _shows = Shows(this);
   }
 
-  SpotifyApiBase(SpotifyApiCredentials credentials,
-      [http.BaseClient httpClient])
-      : this.fromClient(_getOauth2Client(credentials, httpClient));
+  SpotifyApiBase(SpotifyApiCredentials credentials, [http.BaseClient httpClient, Function(SpotifyApiCredentials) callBack]) : this.fromClient(_getOauth2Client(credentials, httpClient, callBack));
+ 
+  SpotifyApiBase.fromAuthCodeGrant(oauth2.AuthorizationCodeGrant grant, String responseUri)
+      : this.fromClient(grant.handleAuthorizationResponse(Uri.parse(responseUri).queryParameters));
 
-  SpotifyApiBase.fromAuthCodeGrant(
-      oauth2.AuthorizationCodeGrant grant, String responseUri)
-      : this.fromClient(grant.handleAuthorizationResponse(
-            Uri.parse(responseUri).queryParameters));
-
-  static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
-      SpotifyApiCredentials credentials, http.BaseClient httpClient) {
-    return oauth2.AuthorizationCodeGrant(
-        credentials.clientId,
-        Uri.parse(SpotifyApiBase._authorizationUrl),
-        Uri.parse(SpotifyApiBase._tokenUrl),
-        secret: credentials.clientSecret,
-        httpClient: httpClient);
+  static oauth2.AuthorizationCodeGrant authorizationCodeGrant(SpotifyApiCredentials credentials, http.BaseClient httpClient, [Function(SpotifyApiCredentials) callBack]) {
+    if (callBack == null)
+      return oauth2.AuthorizationCodeGrant(credentials.clientId, Uri.parse(SpotifyApiBase._authorizationUrl), Uri.parse(SpotifyApiBase._tokenUrl),
+          secret: credentials.clientSecret, httpClient: httpClient);
+    else
+      return oauth2.AuthorizationCodeGrant(credentials.clientId, Uri.parse(SpotifyApiBase._authorizationUrl), Uri.parse(SpotifyApiBase._tokenUrl),
+          secret: credentials.clientSecret, httpClient: httpClient, onCredentialsRefreshed: (oauth2.Credentials cred) {
+        SpotifyApiCredentials newCredentials = SpotifyApiCredentials(credentials.clientId, credentials.clientSecret,
+            accessToken: cred.accessToken, expiration: cred.expiration, refreshToken: cred.refreshToken, scopes: cred.scopes);
+        callBack(newCredentials);
+      });
   }
 
-  static FutureOr<oauth2.Client> _getOauth2Client(
-      SpotifyApiCredentials credentials, http.BaseClient httpClient) async {
+  static FutureOr<oauth2.Client> _getOauth2Client(SpotifyApiCredentials credentials, http.BaseClient httpClient,
+      [Function(SpotifyApiCredentials) callBack]) async {
     if (credentials.fullyQualified) {
       var oauthCredentials = credentials._toOauth2Credentials();
 
@@ -82,6 +80,18 @@ abstract class SpotifyApiBase {
           httpClient: httpClient,
         );
       }
+
+      if (callBack != null)
+        return oauth2.Client(
+          oauthCredentials,
+          identifier: credentials.clientId,
+          onCredentialsRefreshed: (oauth2.Credentials cred) {
+            SpotifyApiCredentials newCredentials = SpotifyApiCredentials(credentials.clientId, credentials.clientSecret,
+                accessToken: cred.accessToken, expiration: cred.expiration, refreshToken: cred.refreshToken, scopes: cred.scopes);
+            callBack(newCredentials);
+          },
+          secret: credentials.clientSecret,
+        );
 
       return oauth2.Client(
         oauthCredentials,

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -50,12 +50,14 @@ abstract class SpotifyApiBase {
     _shows = Shows(this);
   }
 
-  SpotifyApiBase(SpotifyApiCredentials credentials, [http.BaseClient httpClient, Function(SpotifyApiCredentials) callBack]) : this.fromClient(_getOauth2Client(credentials, httpClient, callBack));
- 
+  SpotifyApiBase(SpotifyApiCredentials credentials, [http.BaseClient httpClient, Function(SpotifyApiCredentials) callBack])
+      : this.fromClient(_getOauth2Client(credentials, httpClient, callBack));
+
   SpotifyApiBase.fromAuthCodeGrant(oauth2.AuthorizationCodeGrant grant, String responseUri)
       : this.fromClient(grant.handleAuthorizationResponse(Uri.parse(responseUri).queryParameters));
 
-  static oauth2.AuthorizationCodeGrant authorizationCodeGrant(SpotifyApiCredentials credentials, http.BaseClient httpClient, [Function(SpotifyApiCredentials) callBack]) {
+  static oauth2.AuthorizationCodeGrant authorizationCodeGrant(SpotifyApiCredentials credentials, http.BaseClient httpClient,
+      [Function(SpotifyApiCredentials) callBack]) {
     if (callBack == null)
       return oauth2.AuthorizationCodeGrant(credentials.clientId, Uri.parse(SpotifyApiBase._authorizationUrl), Uri.parse(SpotifyApiBase._tokenUrl),
           secret: credentials.clientSecret, httpClient: httpClient);
@@ -81,23 +83,19 @@ abstract class SpotifyApiBase {
         );
       }
 
-      if (callBack != null)
-        return oauth2.Client(
-          oauthCredentials,
-          identifier: credentials.clientId,
-          onCredentialsRefreshed: (oauth2.Credentials cred) {
-            SpotifyApiCredentials newCredentials = SpotifyApiCredentials(credentials.clientId, credentials.clientSecret,
-                accessToken: cred.accessToken, expiration: cred.expiration, refreshToken: cred.refreshToken, scopes: cred.scopes);
-            callBack(newCredentials);
-          },
-          secret: credentials.clientSecret,
-        );
-
       return oauth2.Client(
         oauthCredentials,
         identifier: credentials.clientId,
+        onCredentialsRefreshed: callBack == null
+            ? null
+            : (oauth2.Credentials cred) {
+                SpotifyApiCredentials newCredentials = SpotifyApiCredentials(credentials.clientId, credentials.clientSecret,
+                    accessToken: cred.accessToken, expiration: cred.expiration, refreshToken: cred.refreshToken, scopes: cred.scopes);
+                callBack(newCredentials);
+              },
         secret: credentials.clientSecret,
       );
+ 
     }
 
     return oauth2.clientCredentialsGrant(

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -61,8 +61,8 @@ abstract class SpotifyApiBase {
     if (callBack == null)
       return oauth2.AuthorizationCodeGrant(credentials.clientId, Uri.parse(SpotifyApiBase._authorizationUrl), Uri.parse(SpotifyApiBase._tokenUrl),
           secret: credentials.clientSecret, httpClient: httpClient);
-    else
-      return oauth2.AuthorizationCodeGrant(credentials.clientId, Uri.parse(SpotifyApiBase._authorizationUrl), Uri.parse(SpotifyApiBase._tokenUrl),
+ 
+    return oauth2.AuthorizationCodeGrant(credentials.clientId, Uri.parse(SpotifyApiBase._authorizationUrl), Uri.parse(SpotifyApiBase._tokenUrl),
           secret: credentials.clientSecret, httpClient: httpClient, onCredentialsRefreshed: (oauth2.Credentials cred) {
         SpotifyApiCredentials newCredentials = SpotifyApiCredentials(credentials.clientId, credentials.clientSecret,
             accessToken: cred.accessToken, expiration: cred.expiration, refreshToken: cred.refreshToken, scopes: cred.scopes);


### PR DESCRIPTION
With this PR I've added the ability to get the new credentials obtained when the oAuth library updates them. This is usually the case when the app is open for a very long time and the previous access token is expired while I'm using the app. 
This also solves issue #86.

I've also added some lines in the readme file to notify new users about this feature. 