### PR TITLE
Additional createPlaylist parameters

### DIFF
--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -17,6 +17,7 @@ void main() async {
   }
   await _currentlyPlaying(spotify);
   await _devices(spotify);
+  //await _createPrivatePlaylist(spotify);
 
   exit(0);
 }
@@ -29,7 +30,7 @@ Future<SpotifyApi> _getUserAuthenticatedSpotifyApi(
 
   var grant = SpotifyApi.authorizationCodeGrant(credentials);
   var authUri = grant.getAuthorizationUrl(Uri.parse(redirect),
-      scopes: ['user-read-playback-state']);
+      scopes: ['user-read-playback-state', 'playlist-modify-private']);
 
   print(
       'Please paste this url \n\n$authUri\n\nto your browser and enter the redirected url:');
@@ -51,7 +52,7 @@ void _currentlyPlaying(SpotifyApi spotify) async =>
         print('Nothing currently playing.');
         return;
       }
-      print('Currently playing: ${a.item.name}');
+      print('Currently playing: ${a.item?.name}');
     }).catchError(_prettyPrintError);
 
 void _devices(SpotifyApi spotify) async =>
@@ -64,7 +65,21 @@ void _devices(SpotifyApi spotify) async =>
       print(devices.map((device) => device.name).join(', '));
     }).catchError(_prettyPrintError);
 
-void _prettyPrintError(Exception error) {
+void _createPrivatePlaylist(SpotifyApi spotify) async {
+  var user = await spotify.me.get();
+  await spotify.playlists
+      .createPlaylist(
+    user.id,
+    'Cool New Playlist 2',
+    description: 'Songs to test by',
+    public: false,
+  )
+      .then((playlist) {
+    print('Private playlist created!');
+  }).catchError(_prettyPrintError);
+}
+
+dynamic _prettyPrintError(Object error) {
   if (error is SpotifyException) {
     print('${error.status} : ${error.message}');
   } else {

--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -79,7 +79,7 @@ void _createPrivatePlaylist(SpotifyApi spotify) async {
   }).catchError(_prettyPrintError);
 }
 
-dynamic _prettyPrintError(Object error) {
+void _prettyPrintError(Object error) {
   if (error is SpotifyException) {
     print('${error.status} : ${error.message}');
   } else {

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -36,10 +36,16 @@ class Playlists extends EndpointPaging {
   /// [userId] - the Spotify user ID
   ///
   /// [playlistName] - the name of the new playlist
-  Future<Playlist> createPlaylist(String userId, String playlistName) async {
+  Future<Playlist> createPlaylist(String userId, String playlistName,
+      {bool public, bool collaborative, String description}) async {
     final url = 'v1/users/$userId/playlists';
-    final playlistJson =
-        await _api._post(url, jsonEncode({'name': playlistName}));
+    final json = <String, dynamic>{'name': playlistName};
+
+    if (public != null) json['public'] = public;
+    if (collaborative != null) json['collaborative'] = collaborative;
+    if (description != null) json['description'] = description;
+
+    final playlistJson = await _api._post(url, jsonEncode(json));
     return await Playlist.fromJson(jsonDecode(playlistJson));
   }
 

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -36,6 +36,14 @@ class Playlists extends EndpointPaging {
   /// [userId] - the Spotify user ID
   ///
   /// [playlistName] - the name of the new playlist
+  ///
+  /// [public] - Defaults to `true`. If `true` the playlist will be public,
+  /// if `false` it will be private.
+  ///
+  /// [collaborative] - Defaults to `false`. If `true` the playlist will
+  /// be collaborative.
+  ///
+  /// [description] - the description of the new playlist
   Future<Playlist> createPlaylist(String userId, String playlistName,
       {bool public, bool collaborative, String description}) async {
     final url = 'v1/users/$userId/playlists';


### PR DESCRIPTION
This PR adds optional parameters `public`, `collaborative` and `description` (as stated in the API reference) to the createPlaylist function.

For testing purposes, I wrote an example call in example_auth.dart. You can uncomment [this line](https://github.com/rinukkusu/spotify-dart/compare/master...doodlezucc:master#diff-453b7c78bb316aac18630cae4a77d3edfb33bbd8912bf6eb65f53c1ee7d1da94R20) to try it out.