### PR TITLE
Add example_auth.dart into launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,15 +3,24 @@
     "configurations": [
         {
             "name": "Run tests",
-            "type": "dart-cli",
+            "type": "dart",
             "request": "launch",
+            "console": "debugConsole",
             "program": "${workspaceRoot}/test/spotify_test.dart"
         },
         {
-            "name": "Run example",
-            "type": "dart-cli",
+            "name": "Run example with authentication",
+            "type": "dart",
             "request": "launch",
-            "program": "${workspaceRoot}/example/spotify_dart_example.dart"
+            "console": "terminal",
+            "program": "${workspaceRoot}/example/example_auth.dart"
+        },
+        {
+            "name": "Run example",
+            "type": "dart",
+            "request": "launch",
+            "console": "terminal",
+            "program": "${workspaceRoot}/example/example.dart"
         }
     ]
 }


### PR DESCRIPTION
This PR allows to launching to debug the `example_auth.dart` and `example.dart` accordingly with support of stdin.
It can be launched through this:

![Run debug example](https://user-images.githubusercontent.com/3295340/108594908-006a3a00-737d-11eb-8ce7-b4684a59dbd0.png)
