### PR TITLE
models: generate toJson method for each model

### DIFF
--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -10,12 +10,24 @@ ExternalUrls _$ExternalUrlsFromJson(Map<String, dynamic> json) {
   return ExternalUrls()..spotify = json['spotify'] as String;
 }
 
+Map<String, dynamic> _$ExternalUrlsToJson(ExternalUrls instance) =>
+    <String, dynamic>{
+      'spotify': instance.spotify,
+    };
+
 ExternalIds _$ExternalIdsFromJson(Map<String, dynamic> json) {
   return ExternalIds()
     ..isrc = json['isrc'] as String
     ..ean = json['ean'] as String
     ..upc = json['upc'] as String;
 }
+
+Map<String, dynamic> _$ExternalIdsToJson(ExternalIds instance) =>
+    <String, dynamic>{
+      'isrc': instance.isrc,
+      'ean': instance.ean,
+      'upc': instance.upc,
+    };
 
 Album _$AlbumFromJson(Map<String, dynamic> json) {
   return Album()
@@ -54,6 +66,28 @@ Album _$AlbumFromJson(Map<String, dynamic> json) {
     ..label = json['label'] as String
     ..popularity = json['popularity'] as int;
 }
+
+Map<String, dynamic> _$AlbumToJson(Album instance) => <String, dynamic>{
+      'album_type': instance.albumType,
+      'artists': instance.artists,
+      'available_markets': instance.availableMarkets,
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'name': instance.name,
+      'release_date': instance.releaseDate,
+      'release_date_precision':
+          _$DatePrecisionEnumMap[instance.releaseDatePrecision],
+      'type': instance.type,
+      'uri': instance.uri,
+      'tracks': instance.tracks?.toList(),
+      'copyrights': instance.copyrights,
+      'external_ids': instance.externalIds,
+      'genres': instance.genres,
+      'label': instance.label,
+      'popularity': instance.popularity,
+    };
 
 T _$enumDecode<T>(
   Map<T, dynamic> enumValues,
@@ -121,6 +155,24 @@ AlbumSimple _$AlbumSimpleFromJson(Map<String, dynamic> json) {
         json['tracks'] as Map<String, dynamic>);
 }
 
+Map<String, dynamic> _$AlbumSimpleToJson(AlbumSimple instance) =>
+    <String, dynamic>{
+      'album_type': instance.albumType,
+      'artists': instance.artists,
+      'available_markets': instance.availableMarkets,
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'name': instance.name,
+      'release_date': instance.releaseDate,
+      'release_date_precision':
+          _$DatePrecisionEnumMap[instance.releaseDatePrecision],
+      'type': instance.type,
+      'uri': instance.uri,
+      'tracks': instance.tracks?.toList(),
+    };
+
 Artist _$ArtistFromJson(Map<String, dynamic> json) {
   return Artist()
     ..externalUrls = json['external_urls'] == null
@@ -142,6 +194,19 @@ Artist _$ArtistFromJson(Map<String, dynamic> json) {
     ..popularity = json['popularity'] as int;
 }
 
+Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'name': instance.name,
+      'type': instance.type,
+      'uri': instance.uri,
+      'followers': instance.followers,
+      'genres': instance.genres,
+      'images': instance.images,
+      'popularity': instance.popularity,
+    };
+
 ArtistSimple _$ArtistSimpleFromJson(Map<String, dynamic> json) {
   return ArtistSimple()
     ..externalUrls = json['external_urls'] == null
@@ -153,6 +218,16 @@ ArtistSimple _$ArtistSimpleFromJson(Map<String, dynamic> json) {
     ..type = json['type'] as String
     ..uri = json['uri'] as String;
 }
+
+Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) =>
+    <String, dynamic>{
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'name': instance.name,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
 
 AudioFeature _$AudioFeatureFromJson(Map<String, dynamic> json) {
   return AudioFeature()
@@ -176,6 +251,28 @@ AudioFeature _$AudioFeatureFromJson(Map<String, dynamic> json) {
     ..valence = (json['valence'] as num)?.toDouble();
 }
 
+Map<String, dynamic> _$AudioFeatureToJson(AudioFeature instance) =>
+    <String, dynamic>{
+      'acousticness': instance.acousticness,
+      'analysis_url': instance.analysisUrl,
+      'danceability': instance.danceability,
+      'duration_ms': instance.durationMs,
+      'energy': instance.energy,
+      'id': instance.id,
+      'instrumentalness': instance.instrumentalness,
+      'key': instance.key,
+      'liveness': instance.liveness,
+      'loudness': instance.loudness,
+      'mode': instance.mode,
+      'speechiness': instance.speechiness,
+      'tempo': instance.tempo,
+      'time_signature': instance.timeSignature,
+      'track_href': instance.trackHref,
+      'type': instance.type,
+      'uri': instance.uri,
+      'valence': instance.valence,
+    };
+
 Category _$CategoryFromJson(Map<String, dynamic> json) {
   return Category()
     ..href = json['href'] as String
@@ -187,11 +284,23 @@ Category _$CategoryFromJson(Map<String, dynamic> json) {
     ..name = json['name'] as String;
 }
 
+Map<String, dynamic> _$CategoryToJson(Category instance) => <String, dynamic>{
+      'href': instance.href,
+      'icons': instance.icons,
+      'id': instance.id,
+      'name': instance.name,
+    };
+
 Copyright _$CopyrightFromJson(Map<String, dynamic> json) {
   return Copyright()
     ..text = json['text'] as String
     ..type = json['type'] as String;
 }
+
+Map<String, dynamic> _$CopyrightToJson(Copyright instance) => <String, dynamic>{
+      'text': instance.text,
+      'type': instance.type,
+    };
 
 CursorPaging<T> _$CursorPagingFromJson<T>(Map<String, dynamic> json) {
   return CursorPaging<T>()
@@ -207,9 +316,25 @@ CursorPaging<T> _$CursorPagingFromJson<T>(Map<String, dynamic> json) {
         : Cursor.fromJson(json['cursors'] as Map<String, dynamic>);
 }
 
+Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) =>
+    <String, dynamic>{
+      'href': instance.href,
+      'items': itemsNativeToJson(instance.itemsNative),
+      'limit': instance.limit,
+      'next': instance.next,
+      'offset': instance.offset,
+      'previous': instance.previous,
+      'total': instance.total,
+      'cursors': instance.cursors,
+    };
+
 Cursor _$CursorFromJson(Map<String, dynamic> json) {
   return Cursor()..after = json['after'] as String;
 }
+
+Map<String, dynamic> _$CursorToJson(Cursor instance) => <String, dynamic>{
+      'after': instance.after,
+    };
 
 Device _$DeviceFromJson(Map<String, dynamic> json) {
   return Device()
@@ -221,6 +346,16 @@ Device _$DeviceFromJson(Map<String, dynamic> json) {
     ..type = _$enumDecodeNullable(_$DeviceTypeEnumMap, json['type'])
     ..volumePercent = json['volume_percent'] as int;
 }
+
+Map<String, dynamic> _$DeviceToJson(Device instance) => <String, dynamic>{
+      'id': instance.id,
+      'is_active': instance.isActive,
+      'is_private_session': instance.isPrivateSession,
+      'is_restricted': instance.isRestricted,
+      'name': instance.name,
+      'type': _$DeviceTypeEnumMap[instance.type],
+      'volume_percent': instance.volumePercent,
+    };
 
 const _$DeviceTypeEnumMap = {
   DeviceType.Computer: 'Computer',
@@ -244,11 +379,22 @@ SpotifyError _$SpotifyErrorFromJson(Map<String, dynamic> json) {
     ..message = json['message'] as String;
 }
 
+Map<String, dynamic> _$SpotifyErrorToJson(SpotifyError instance) =>
+    <String, dynamic>{
+      'status': instance.status,
+      'message': instance.message,
+    };
+
 Followers _$FollowersFromJson(Map<String, dynamic> json) {
   return Followers()
     ..href = json['href'] as String
     ..total = json['total'] as int;
 }
+
+Map<String, dynamic> _$FollowersToJson(Followers instance) => <String, dynamic>{
+      'href': instance.href,
+      'total': instance.total,
+    };
 
 Image _$ImageFromJson(Map<String, dynamic> json) {
   return Image()
@@ -256,6 +402,12 @@ Image _$ImageFromJson(Map<String, dynamic> json) {
     ..width = json['width'] as int
     ..url = json['url'] as String;
 }
+
+Map<String, dynamic> _$ImageToJson(Image instance) => <String, dynamic>{
+      'height': instance.height,
+      'width': instance.width,
+      'url': instance.url,
+    };
 
 Paging<T> _$PagingFromJson<T>(Map<String, dynamic> json) {
   return Paging<T>()
@@ -267,6 +419,16 @@ Paging<T> _$PagingFromJson<T>(Map<String, dynamic> json) {
     ..previous = json['previous'] as String
     ..total = json['total'] as int;
 }
+
+Map<String, dynamic> _$PagingToJson<T>(Paging<T> instance) => <String, dynamic>{
+      'href': instance.href,
+      'items': itemsNativeToJson(instance.itemsNative),
+      'limit': instance.limit,
+      'next': instance.next,
+      'offset': instance.offset,
+      'previous': instance.previous,
+      'total': instance.total,
+    };
 
 Player _$PlayerFromJson(Map<String, dynamic> json) {
   return Player()
@@ -282,6 +444,15 @@ Player _$PlayerFromJson(Map<String, dynamic> json) {
     ..is_playing = json['is_playing'] as bool;
 }
 
+Map<String, dynamic> _$PlayerToJson(Player instance) => <String, dynamic>{
+      'timestamp': instance.timestamp,
+      'context': instance.context,
+      'progress_ms': instance.progress_ms,
+      'item': instance.item,
+      'currently_playing_type': instance.currently_playing_type,
+      'is_playing': instance.is_playing,
+    };
+
 PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) {
   return PlayerContext()
     ..external_urls = json['external_urls'] == null
@@ -291,6 +462,14 @@ PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) {
     ..type = json['type'] as String
     ..uri = json['uri'] as String;
 }
+
+Map<String, dynamic> _$PlayerContextToJson(PlayerContext instance) =>
+    <String, dynamic>{
+      'external_urls': instance.external_urls,
+      'href': instance.href,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
 
 Playlist _$PlaylistFromJson(Map<String, dynamic> json) {
   return Playlist()
@@ -321,6 +500,23 @@ Playlist _$PlaylistFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$PlaylistToJson(Playlist instance) => <String, dynamic>{
+      'collaborative': instance.collaborative,
+      'description': instance.description,
+      'external_urls': instance.externalUrls,
+      'followers': instance.followers,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'name': instance.name,
+      'owner': instance.owner,
+      'public': instance.public,
+      'snapshot_id': instance.snapshotId,
+      'tracks': instance.tracks,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 PlaylistSimple _$PlaylistSimpleFromJson(Map<String, dynamic> json) {
   return PlaylistSimple()
     ..collaborative = json['collaborative'] as bool
@@ -346,9 +542,30 @@ PlaylistSimple _$PlaylistSimpleFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$PlaylistSimpleToJson(PlaylistSimple instance) =>
+    <String, dynamic>{
+      'collaborative': instance.collaborative,
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'name': instance.name,
+      'owner': instance.owner,
+      'public': instance.public,
+      'snapshot_id': instance.snapshotId,
+      'tracks': instance.tracksLink,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 PlaylistsFeatured _$PlaylistsFeaturedFromJson(Map<String, dynamic> json) {
   return PlaylistsFeatured()..message = json['message'] as String;
 }
+
+Map<String, dynamic> _$PlaylistsFeaturedToJson(PlaylistsFeatured instance) =>
+    <String, dynamic>{
+      'message': instance.message,
+    };
 
 PlaylistTrack _$PlaylistTrackFromJson(Map<String, dynamic> json) {
   return PlaylistTrack()
@@ -364,6 +581,14 @@ PlaylistTrack _$PlaylistTrackFromJson(Map<String, dynamic> json) {
         : Track.fromJson(json['track'] as Map<String, dynamic>);
 }
 
+Map<String, dynamic> _$PlaylistTrackToJson(PlaylistTrack instance) =>
+    <String, dynamic>{
+      'added_at': instance.addedAt?.toIso8601String(),
+      'added_by': instance.addedBy,
+      'is_local': instance.isLocal,
+      'track': instance.track,
+    };
+
 Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) {
   return Recommendations()
     ..seeds = (json['seeds'] as List)
@@ -377,6 +602,12 @@ Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) {
         ?.toList();
 }
 
+Map<String, dynamic> _$RecommendationsToJson(Recommendations instance) =>
+    <String, dynamic>{
+      'seeds': instance.seeds,
+      'tracks': instance.tracks,
+    };
+
 RecommendationsSeed _$RecommendationsSeedFromJson(Map<String, dynamic> json) {
   return RecommendationsSeed()
     ..afterFilteringSize = json['afterFilteringSize'] as int
@@ -386,6 +617,17 @@ RecommendationsSeed _$RecommendationsSeedFromJson(Map<String, dynamic> json) {
     ..initialPoolSize = json['initialPoolSize'] as int
     ..type = json['type'] as String;
 }
+
+Map<String, dynamic> _$RecommendationsSeedToJson(
+        RecommendationsSeed instance) =>
+    <String, dynamic>{
+      'afterFilteringSize': instance.afterFilteringSize,
+      'afterRelinkingSize': instance.afterRelinkingSize,
+      'href': instance.href,
+      'id': instance.id,
+      'initialPoolSize': instance.initialPoolSize,
+      'type': instance.type,
+    };
 
 Show _$ShowFromJson(Map<String, dynamic> json) {
   return Show()
@@ -415,6 +657,24 @@ Show _$ShowFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$ShowToJson(Show instance) => <String, dynamic>{
+      'available_markets': instance.availableMarkets,
+      'copyrights': instance.copyrights,
+      'description': instance.description,
+      'explicit': instance.explicit,
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'is_externally_hosted': instance.isExternallyHosted,
+      'languages': instance.languages,
+      'media_type': instance.mediaType,
+      'name': instance.name,
+      'publisher': instance.publisher,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 Episode _$EpisodeFromJson(Map<String, dynamic> json) {
   return Episode()
     ..audioPreviewUrl = json['audio_preview_url'] as String
@@ -442,6 +702,26 @@ Episode _$EpisodeFromJson(Map<String, dynamic> json) {
     ..type = json['type'] as String
     ..uri = json['uri'] as String;
 }
+
+Map<String, dynamic> _$EpisodeToJson(Episode instance) => <String, dynamic>{
+      'audio_preview_url': instance.audioPreviewUrl,
+      'description': instance.description,
+      'duration_ms': instance.durationMs,
+      'explicit': instance.explicit,
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'is_externally_hosted': instance.isExternallyHosted,
+      'is_playable': instance.isPlayable,
+      'language': instance.language,
+      'languages': instance.languages,
+      'name': instance.name,
+      'release_date': instance.releaseDate?.toIso8601String(),
+      'release_date_precision': instance.releaseDatePrecision,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
 
 Track _$TrackFromJson(Map<String, dynamic> json) {
   return Track()
@@ -477,6 +757,27 @@ Track _$TrackFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$TrackToJson(Track instance) => <String, dynamic>{
+      'album': instance.album,
+      'artists': instance.artists,
+      'available_markets': instance.availableMarkets,
+      'disc_number': instance.discNumber,
+      'duration_ms': instance.durationMs,
+      'explicit': instance.explicit,
+      'external_ids': instance.externalIds,
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'is_playable': instance.isPlayable,
+      'linked_from': instance.linkedFrom,
+      'name': instance.name,
+      'popularity': instance.popularity,
+      'preview_url': instance.previewUrl,
+      'track_number': instance.trackNumber,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 TrackSimple _$TrackSimpleFromJson(Map<String, dynamic> json) {
   return TrackSimple()
     ..artists = (json['artists'] as List)
@@ -504,6 +805,25 @@ TrackSimple _$TrackSimpleFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) =>
+    <String, dynamic>{
+      'artists': instance.artists,
+      'available_markets': instance.availableMarkets,
+      'disc_number': instance.discNumber,
+      'duration_ms': instance.durationMs,
+      'explicit': instance.explicit,
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'is_playable': instance.isPlayable,
+      'linked_from': instance.linkedFrom,
+      'name': instance.name,
+      'preview_url': instance.previewUrl,
+      'track_number': instance.trackNumber,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 TrackSaved _$TrackSavedFromJson(Map<String, dynamic> json) {
   return TrackSaved()
     ..addedAt = json['added_at'] == null
@@ -513,6 +833,12 @@ TrackSaved _$TrackSavedFromJson(Map<String, dynamic> json) {
         ? null
         : Track.fromJson(json['track'] as Map<String, dynamic>);
 }
+
+Map<String, dynamic> _$TrackSavedToJson(TrackSaved instance) =>
+    <String, dynamic>{
+      'added_at': instance.addedAt?.toIso8601String(),
+      'track': instance.track,
+    };
 
 TrackLink _$TrackLinkFromJson(Map<String, dynamic> json) {
   return TrackLink()
@@ -525,11 +851,25 @@ TrackLink _$TrackLinkFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$TrackLinkToJson(TrackLink instance) => <String, dynamic>{
+      'external_urls': instance.externalUrls,
+      'href': instance.href,
+      'id': instance.id,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 TracksLink _$TracksLinkFromJson(Map<String, dynamic> json) {
   return TracksLink()
     ..href = json['href'] as String
     ..total = json['total'] as int;
 }
+
+Map<String, dynamic> _$TracksLinkToJson(TracksLink instance) =>
+    <String, dynamic>{
+      'href': instance.href,
+      'total': instance.total,
+    };
 
 User _$UserFromJson(Map<String, dynamic> json) {
   return User()
@@ -551,6 +891,20 @@ User _$UserFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+      'birthdate': instance.birthdate,
+      'country': instance.country,
+      'display_name': instance.displayName,
+      'email': instance.email,
+      'followers': instance.followers,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'product': instance.product,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 UserPublic _$UserPublicFromJson(Map<String, dynamic> json) {
   return UserPublic()
     ..displayName = json['display_name'] as String
@@ -567,6 +921,17 @@ UserPublic _$UserPublicFromJson(Map<String, dynamic> json) {
     ..uri = json['uri'] as String;
 }
 
+Map<String, dynamic> _$UserPublicToJson(UserPublic instance) =>
+    <String, dynamic>{
+      'display_name': instance.displayName,
+      'followers': instance.followers,
+      'href': instance.href,
+      'id': instance.id,
+      'images': instance.images,
+      'type': instance.type,
+      'uri': instance.uri,
+    };
+
 PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) {
   return PlayHistory()
     ..track = json['track'] == null
@@ -579,3 +944,10 @@ PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) {
         ? null
         : PlayerContext.fromJson(json['context'] as Map<String, dynamic>);
 }
+
+Map<String, dynamic> _$PlayHistoryToJson(PlayHistory instance) =>
+    <String, dynamic>{
+      'track': instance.track,
+      'played_at': instance.playedAt?.toIso8601String(),
+      'context': instance.context,
+    };

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -69,21 +69,21 @@ Album _$AlbumFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$AlbumToJson(Album instance) => <String, dynamic>{
       'album_type': instance.albumType,
-      'artists': instance.artists,
+      'artists': instance.artists?.map((e) => e?.toJson())?.toList(),
       'available_markets': instance.availableMarkets,
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'name': instance.name,
       'release_date': instance.releaseDate,
       'release_date_precision':
           _$DatePrecisionEnumMap[instance.releaseDatePrecision],
       'type': instance.type,
       'uri': instance.uri,
-      'tracks': instance.tracks?.toList(),
-      'copyrights': instance.copyrights,
-      'external_ids': instance.externalIds,
+      'tracks': instance.tracks?.map((e) => e?.toJson())?.toList(),
+      'copyrights': instance.copyrights?.map((e) => e?.toJson())?.toList(),
+      'external_ids': instance.externalIds?.toJson(),
       'genres': instance.genres,
       'label': instance.label,
       'popularity': instance.popularity,
@@ -158,19 +158,19 @@ AlbumSimple _$AlbumSimpleFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$AlbumSimpleToJson(AlbumSimple instance) =>
     <String, dynamic>{
       'album_type': instance.albumType,
-      'artists': instance.artists,
+      'artists': instance.artists?.map((e) => e?.toJson())?.toList(),
       'available_markets': instance.availableMarkets,
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'name': instance.name,
       'release_date': instance.releaseDate,
       'release_date_precision':
           _$DatePrecisionEnumMap[instance.releaseDatePrecision],
       'type': instance.type,
       'uri': instance.uri,
-      'tracks': instance.tracks?.toList(),
+      'tracks': instance.tracks?.map((e) => e?.toJson())?.toList(),
     };
 
 Artist _$ArtistFromJson(Map<String, dynamic> json) {
@@ -195,15 +195,15 @@ Artist _$ArtistFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'name': instance.name,
       'type': instance.type,
       'uri': instance.uri,
-      'followers': instance.followers,
+      'followers': instance.followers?.toJson(),
       'genres': instance.genres,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'popularity': instance.popularity,
     };
 
@@ -221,7 +221,7 @@ ArtistSimple _$ArtistSimpleFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) =>
     <String, dynamic>{
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'name': instance.name,
@@ -286,7 +286,7 @@ Category _$CategoryFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$CategoryToJson(Category instance) => <String, dynamic>{
       'href': instance.href,
-      'icons': instance.icons,
+      'icons': instance.icons?.map((e) => e?.toJson())?.toList(),
       'id': instance.id,
       'name': instance.name,
     };
@@ -325,7 +325,7 @@ Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) =>
       'offset': instance.offset,
       'previous': instance.previous,
       'total': instance.total,
-      'cursors': instance.cursors,
+      'cursors': instance.cursors?.toJson(),
     };
 
 Cursor _$CursorFromJson(Map<String, dynamic> json) {
@@ -446,9 +446,9 @@ Player _$PlayerFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$PlayerToJson(Player instance) => <String, dynamic>{
       'timestamp': instance.timestamp,
-      'context': instance.context,
+      'context': instance.context?.toJson(),
       'progress_ms': instance.progress_ms,
-      'item': instance.item,
+      'item': instance.item?.toJson(),
       'currently_playing_type': instance.currently_playing_type,
       'is_playing': instance.is_playing,
     };
@@ -465,7 +465,7 @@ PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$PlayerContextToJson(PlayerContext instance) =>
     <String, dynamic>{
-      'external_urls': instance.external_urls,
+      'external_urls': instance.external_urls?.toJson(),
       'href': instance.href,
       'type': instance.type,
       'uri': instance.uri,
@@ -503,16 +503,16 @@ Playlist _$PlaylistFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$PlaylistToJson(Playlist instance) => <String, dynamic>{
       'collaborative': instance.collaborative,
       'description': instance.description,
-      'external_urls': instance.externalUrls,
-      'followers': instance.followers,
+      'external_urls': instance.externalUrls?.toJson(),
+      'followers': instance.followers?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'name': instance.name,
-      'owner': instance.owner,
+      'owner': instance.owner?.toJson(),
       'public': instance.public,
       'snapshot_id': instance.snapshotId,
-      'tracks': instance.tracks,
+      'tracks': instance.tracks?.toJson(),
       'type': instance.type,
       'uri': instance.uri,
     };
@@ -545,15 +545,15 @@ PlaylistSimple _$PlaylistSimpleFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$PlaylistSimpleToJson(PlaylistSimple instance) =>
     <String, dynamic>{
       'collaborative': instance.collaborative,
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'name': instance.name,
-      'owner': instance.owner,
+      'owner': instance.owner?.toJson(),
       'public': instance.public,
       'snapshot_id': instance.snapshotId,
-      'tracks': instance.tracksLink,
+      'tracks': instance.tracksLink?.toJson(),
       'type': instance.type,
       'uri': instance.uri,
     };
@@ -584,9 +584,9 @@ PlaylistTrack _$PlaylistTrackFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$PlaylistTrackToJson(PlaylistTrack instance) =>
     <String, dynamic>{
       'added_at': instance.addedAt?.toIso8601String(),
-      'added_by': instance.addedBy,
+      'added_by': instance.addedBy?.toJson(),
       'is_local': instance.isLocal,
-      'track': instance.track,
+      'track': instance.track?.toJson(),
     };
 
 Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) {
@@ -604,8 +604,8 @@ Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$RecommendationsToJson(Recommendations instance) =>
     <String, dynamic>{
-      'seeds': instance.seeds,
-      'tracks': instance.tracks,
+      'seeds': instance.seeds?.map((e) => e?.toJson())?.toList(),
+      'tracks': instance.tracks?.map((e) => e?.toJson())?.toList(),
     };
 
 RecommendationsSeed _$RecommendationsSeedFromJson(Map<String, dynamic> json) {
@@ -659,13 +659,13 @@ Show _$ShowFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$ShowToJson(Show instance) => <String, dynamic>{
       'available_markets': instance.availableMarkets,
-      'copyrights': instance.copyrights,
+      'copyrights': instance.copyrights?.map((e) => e?.toJson())?.toList(),
       'description': instance.description,
       'explicit': instance.explicit,
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'is_externally_hosted': instance.isExternallyHosted,
       'languages': instance.languages,
       'media_type': instance.mediaType,
@@ -708,10 +708,10 @@ Map<String, dynamic> _$EpisodeToJson(Episode instance) => <String, dynamic>{
       'description': instance.description,
       'duration_ms': instance.durationMs,
       'explicit': instance.explicit,
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'is_externally_hosted': instance.isExternallyHosted,
       'is_playable': instance.isPlayable,
       'language': instance.language,
@@ -758,18 +758,18 @@ Track _$TrackFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$TrackToJson(Track instance) => <String, dynamic>{
-      'album': instance.album,
-      'artists': instance.artists,
+      'album': instance.album?.toJson(),
+      'artists': instance.artists?.map((e) => e?.toJson())?.toList(),
       'available_markets': instance.availableMarkets,
       'disc_number': instance.discNumber,
       'duration_ms': instance.durationMs,
       'explicit': instance.explicit,
-      'external_ids': instance.externalIds,
-      'external_urls': instance.externalUrls,
+      'external_ids': instance.externalIds?.toJson(),
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'is_playable': instance.isPlayable,
-      'linked_from': instance.linkedFrom,
+      'linked_from': instance.linkedFrom?.toJson(),
       'name': instance.name,
       'popularity': instance.popularity,
       'preview_url': instance.previewUrl,
@@ -807,16 +807,16 @@ TrackSimple _$TrackSimpleFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) =>
     <String, dynamic>{
-      'artists': instance.artists,
+      'artists': instance.artists?.map((e) => e?.toJson())?.toList(),
       'available_markets': instance.availableMarkets,
       'disc_number': instance.discNumber,
       'duration_ms': instance.durationMs,
       'explicit': instance.explicit,
-      'external_urls': instance.externalUrls,
+      'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'is_playable': instance.isPlayable,
-      'linked_from': instance.linkedFrom,
+      'linked_from': instance.linkedFrom?.toJson(),
       'name': instance.name,
       'preview_url': instance.previewUrl,
       'track_number': instance.trackNumber,
@@ -837,7 +837,7 @@ TrackSaved _$TrackSavedFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$TrackSavedToJson(TrackSaved instance) =>
     <String, dynamic>{
       'added_at': instance.addedAt?.toIso8601String(),
-      'track': instance.track,
+      'track': instance.track?.toJson(),
     };
 
 TrackLink _$TrackLinkFromJson(Map<String, dynamic> json) {
@@ -896,10 +896,10 @@ Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
       'country': instance.country,
       'display_name': instance.displayName,
       'email': instance.email,
-      'followers': instance.followers,
+      'followers': instance.followers?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'product': instance.product,
       'type': instance.type,
       'uri': instance.uri,
@@ -924,10 +924,10 @@ UserPublic _$UserPublicFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$UserPublicToJson(UserPublic instance) =>
     <String, dynamic>{
       'display_name': instance.displayName,
-      'followers': instance.followers,
+      'followers': instance.followers?.toJson(),
       'href': instance.href,
       'id': instance.id,
-      'images': instance.images,
+      'images': instance.images?.map((e) => e?.toJson())?.toList(),
       'type': instance.type,
       'uri': instance.uri,
     };
@@ -947,7 +947,7 @@ PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$PlayHistoryToJson(PlayHistory instance) =>
     <String, dynamic>{
-      'track': instance.track,
+      'track': instance.track?.toJson(),
       'played_at': instance.playedAt?.toIso8601String(),
-      'context': instance.context,
+      'context': instance.context?.toJson(),
     };

--- a/lib/src/models/album.dart
+++ b/lib/src/models/album.dart
@@ -3,11 +3,13 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Album extends AlbumSimple {
   Album();
 
   factory Album.fromJson(Map<String, dynamic> json) => _$AlbumFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AlbumToJson(this);
 
   /// The copyright statements of the album.
   List<Copyright> copyrights;
@@ -32,12 +34,13 @@ class Album extends AlbumSimple {
   int popularity;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class AlbumSimple extends Object {
   AlbumSimple();
 
   factory AlbumSimple.fromJson(Map<String, dynamic> json) =>
       _$AlbumSimpleFromJson(json);
+  Map<String, dynamic> toJson() => _$AlbumSimpleToJson(this);
 
   /// Helper function that unwraps the items from the paging object.
   static Iterable<TrackSimple> _extractTracksFromPage(

--- a/lib/src/models/album.dart
+++ b/lib/src/models/album.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Album extends AlbumSimple {
   Album();
 
@@ -34,7 +34,7 @@ class Album extends AlbumSimple {
   int popularity;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AlbumSimple extends Object {
   AlbumSimple();
 

--- a/lib/src/models/artist.dart
+++ b/lib/src/models/artist.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Artist extends Object implements ArtistSimple {
   Artist();
 
@@ -55,7 +55,7 @@ class Artist extends Object implements ArtistSimple {
   int popularity;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class ArtistSimple extends Object {
   ArtistSimple();
 

--- a/lib/src/models/artist.dart
+++ b/lib/src/models/artist.dart
@@ -3,11 +3,13 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Artist extends Object implements ArtistSimple {
   Artist();
 
   factory Artist.fromJson(Map<String, dynamic> json) => _$ArtistFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ArtistToJson(this);
 
   /// Known external URLs for this artist.
   @JsonKey(name: 'external_urls')
@@ -53,12 +55,14 @@ class Artist extends Object implements ArtistSimple {
   int popularity;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class ArtistSimple extends Object {
   ArtistSimple();
 
   factory ArtistSimple.fromJson(Map<String, dynamic> json) =>
       _$ArtistSimpleFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ArtistSimpleToJson(this);
 
   /// Known external URLs for this artist.
   @JsonKey(name: 'external_urls')

--- a/lib/src/models/audio_feature.dart
+++ b/lib/src/models/audio_feature.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class AudioFeature extends Object {
   AudioFeature();
 

--- a/lib/src/models/audio_feature.dart
+++ b/lib/src/models/audio_feature.dart
@@ -3,12 +3,14 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class AudioFeature extends Object {
   AudioFeature();
 
   factory AudioFeature.fromJson(Map<String, dynamic> json) =>
       _$AudioFeatureFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AudioFeatureToJson(this);
 
   /// A confidence measure from 0.0 to 1.0 of whether the track is acoustic.
   /// 1.0 represents high confidence the track is acoustic.

--- a/lib/src/models/category.dart
+++ b/lib/src/models/category.dart
@@ -1,6 +1,6 @@
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Category extends Object {
   Category();
 

--- a/lib/src/models/category.dart
+++ b/lib/src/models/category.dart
@@ -1,11 +1,13 @@
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Category extends Object {
   Category();
 
   factory Category.fromJson(Map<String, dynamic> json) =>
       _$CategoryFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CategoryToJson(this);
 
   /// A link to the Web API endpoint returning full details of the category.
   String href;

--- a/lib/src/models/copyright.dart
+++ b/lib/src/models/copyright.dart
@@ -3,11 +3,13 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Copyright extends Object {
   Copyright();
   factory Copyright.fromJson(Map<String, dynamic> json) =>
       _$CopyrightFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CopyrightToJson(this);
 
   /// The copyright text for this album.
   String text;

--- a/lib/src/models/copyright.dart
+++ b/lib/src/models/copyright.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Copyright extends Object {
   Copyright();
   factory Copyright.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/models/cursor_paging.dart
+++ b/lib/src/models/cursor_paging.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class CursorPaging<T> extends Paging<T> {
   CursorPaging();
 
@@ -15,7 +15,7 @@ class CursorPaging<T> extends Paging<T> {
   Cursor cursors;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Cursor extends Object {
   factory Cursor.fromJson(Map<String, dynamic> json) => _$CursorFromJson(json);
 

--- a/lib/src/models/cursor_paging.dart
+++ b/lib/src/models/cursor_paging.dart
@@ -3,19 +3,23 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class CursorPaging<T> extends Paging<T> {
   CursorPaging();
 
   factory CursorPaging.fromJson(Map<String, dynamic> json) =>
       _$CursorPagingFromJson(json);
 
+  Map<String, dynamic> toJson() => _$CursorPagingToJson(this);
+
   Cursor cursors;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Cursor extends Object {
   factory Cursor.fromJson(Map<String, dynamic> json) => _$CursorFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CursorToJson(this);
 
   Cursor();
   String after;

--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Device extends Object {
   Device();
 

--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -3,11 +3,13 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Device extends Object {
   Device();
 
   factory Device.fromJson(Map<String, dynamic> json) => _$DeviceFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeviceToJson(this);
 
   /// The device ID. This may be [null].
   String id;

--- a/lib/src/models/episode.dart
+++ b/lib/src/models/episode.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Episode extends Object {
   Episode();
 
@@ -74,4 +74,6 @@ class Episode extends Object {
 
   factory Episode.fromJson(Map<String, dynamic> json) =>
       _$EpisodeFromJson(json);
+
+  Map<String, dynamic> toJson() => _$EpisodeToJson(this);
 }

--- a/lib/src/models/episode.dart
+++ b/lib/src/models/episode.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Episode extends Object {
   Episode();
 

--- a/lib/src/models/error.dart
+++ b/lib/src/models/error.dart
@@ -3,12 +3,14 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class SpotifyError extends Object {
   SpotifyError();
 
   factory SpotifyError.fromJson(Map<String, dynamic> json) =>
       _$SpotifyErrorFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SpotifyErrorToJson(this);
 
   /// The HTTP status code (also returned in the response header; see Response
   /// Status Codes for more information).

--- a/lib/src/models/error.dart
+++ b/lib/src/models/error.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SpotifyError extends Object {
   SpotifyError();
 

--- a/lib/src/models/external_objects.dart
+++ b/lib/src/models/external_objects.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class ExternalUrls extends Object {
   ExternalUrls();
 
@@ -16,7 +16,7 @@ class ExternalUrls extends Object {
   String spotify;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class ExternalIds extends Object {
   ExternalIds();
 

--- a/lib/src/models/external_objects.dart
+++ b/lib/src/models/external_objects.dart
@@ -3,23 +3,27 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class ExternalUrls extends Object {
   ExternalUrls();
 
   factory ExternalUrls.fromJson(Map<String, dynamic> json) =>
       _$ExternalUrlsFromJson(json);
 
+  Map<String, dynamic> toJson() => _$ExternalUrlsToJson(this);
+
   /// The Spotify URL for the object.
   String spotify;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class ExternalIds extends Object {
   ExternalIds();
 
   factory ExternalIds.fromJson(Map<String, dynamic> json) =>
       _$ExternalIdsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ExternalIdsToJson(this);
 
   /// International Standard Recording Code
   String isrc;

--- a/lib/src/models/followers.dart
+++ b/lib/src/models/followers.dart
@@ -3,12 +3,14 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Followers extends Object {
   Followers();
 
   factory Followers.fromJson(Map<String, dynamic> json) =>
       _$FollowersFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FollowersToJson(this);
 
   /// A link to the Web API endpoint providing full details of the followers;
   /// null if not available.

--- a/lib/src/models/followers.dart
+++ b/lib/src/models/followers.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Followers extends Object {
   Followers();
 

--- a/lib/src/models/image.dart
+++ b/lib/src/models/image.dart
@@ -3,11 +3,13 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Image extends Object {
   Image();
 
   factory Image.fromJson(Map<String, dynamic> json) => _$ImageFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ImageToJson(this);
 
   /// The image height in pixels. If unknown: null or not returned.
   int height;

--- a/lib/src/models/image.dart
+++ b/lib/src/models/image.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Image extends Object {
   Image();
 

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -8,11 +8,13 @@ typedef ParserFunction<T> = T Function(dynamic object);
 Iterable<dynamic> itemsNativeFromJson(List<dynamic> json) => json;
 List<Map> itemsNativeToJson(Iterable<dynamic> items) => List.from(items);
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Paging<T> extends Object {
   Paging();
 
   factory Paging.fromJson(Map<String, dynamic> json) => _$PagingFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PagingToJson(this);
 
   /// A link to the Web API endpoint returning the full result of the request.
   String href;

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -8,7 +8,7 @@ typedef ParserFunction<T> = T Function(dynamic object);
 Iterable<dynamic> itemsNativeFromJson(List<dynamic> json) => json;
 List<Map> itemsNativeToJson(Iterable<dynamic> items) => List.from(items);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Paging<T> extends Object {
   Paging();
 

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Player extends Object {
   Player() {
     is_playing = false;
@@ -33,7 +33,7 @@ class Player extends Object {
   bool is_playing;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class PlayerContext extends Object {
   PlayerContext();
 

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -3,13 +3,15 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Player extends Object {
   Player() {
     is_playing = false;
   }
 
   factory Player.fromJson(Map<String, dynamic> json) => _$PlayerFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PlayerToJson(this);
 
   /// Unix Millisecond Timestamp when data was fetched
   int timestamp;
@@ -31,12 +33,14 @@ class Player extends Object {
   bool is_playing;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class PlayerContext extends Object {
   PlayerContext();
 
   factory PlayerContext.fromJson(Map<String, dynamic> json) =>
       _$PlayerContextFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PlayerContextToJson(this);
 
   /// The external_urls of the context, or [null] if not available.
   ExternalUrls external_urls;

--- a/lib/src/models/playlist.dart
+++ b/lib/src/models/playlist.dart
@@ -3,12 +3,14 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Playlist extends Object implements PlaylistSimple {
   Playlist();
 
   factory Playlist.fromJson(Map<String, dynamic> json) =>
       _$PlaylistFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PlaylistToJson(this);
 
   /// true if the owner allows other users to modify the playlist.
   @override
@@ -80,11 +82,13 @@ class Playlist extends Object implements PlaylistSimple {
   String uri;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class PlaylistSimple extends Object {
   PlaylistSimple();
   factory PlaylistSimple.fromJson(Map<String, dynamic> json) =>
       _$PlaylistSimpleFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PlaylistSimpleToJson(this);
 
   /// true if the owner allows other users to modify the playlist.
   bool collaborative;
@@ -136,21 +140,25 @@ class PlaylistSimple extends Object {
   String uri;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class PlaylistsFeatured extends Object {
   PlaylistsFeatured();
   factory PlaylistsFeatured.fromJson(Map<String, dynamic> json) =>
       _$PlaylistsFeaturedFromJson(json);
 
+  Map<String, dynamic> toJson() => _$PlaylistsFeaturedToJson(this);
+
   /// The message of the day for Spotify's featured playlists
   String message;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class PlaylistTrack extends Object {
   PlaylistTrack();
   factory PlaylistTrack.fromJson(Map<String, dynamic> json) =>
       _$PlaylistTrackFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PlaylistTrackToJson(this);
 
   /// The date and time the track was added.
   /// Note that some very old playlists may return [null] in this field.

--- a/lib/src/models/playlist.dart
+++ b/lib/src/models/playlist.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Playlist extends Object implements PlaylistSimple {
   Playlist();
 
@@ -82,7 +82,7 @@ class Playlist extends Object implements PlaylistSimple {
   String uri;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class PlaylistSimple extends Object {
   PlaylistSimple();
   factory PlaylistSimple.fromJson(Map<String, dynamic> json) =>
@@ -140,7 +140,7 @@ class PlaylistSimple extends Object {
   String uri;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class PlaylistsFeatured extends Object {
   PlaylistsFeatured();
   factory PlaylistsFeatured.fromJson(Map<String, dynamic> json) =>
@@ -152,7 +152,7 @@ class PlaylistsFeatured extends Object {
   String message;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class PlaylistTrack extends Object {
   PlaylistTrack();
   factory PlaylistTrack.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/models/recommendations.dart
+++ b/lib/src/models/recommendations.dart
@@ -1,6 +1,6 @@
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Recommendations extends Object {
   Recommendations();
 
@@ -17,7 +17,7 @@ class Recommendations extends Object {
   List<TrackSimple> tracks;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class RecommendationsSeed extends Object {
   RecommendationsSeed();
 

--- a/lib/src/models/recommendations.dart
+++ b/lib/src/models/recommendations.dart
@@ -1,11 +1,13 @@
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
-class Recommendations extends Object{
+@JsonSerializable()
+class Recommendations extends Object {
   Recommendations();
 
   factory Recommendations.fromJson(Map<String, dynamic> json) =>
       _$RecommendationsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RecommendationsToJson(this);
 
   /// A List of [RecommendationSeed] objects.
   List<RecommendationsSeed> seeds;
@@ -15,12 +17,14 @@ class Recommendations extends Object{
   List<TrackSimple> tracks;
 }
 
-@JsonSerializable(createToJson: false)
-class RecommendationsSeed extends Object{
+@JsonSerializable()
+class RecommendationsSeed extends Object {
   RecommendationsSeed();
 
   factory RecommendationsSeed.fromJson(Map<String, dynamic> json) =>
-    _$RecommendationsSeedFromJson(json);
+      _$RecommendationsSeedFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RecommendationsSeedToJson(this);
 
   /// The number of tracks available after min_* and max_* filters
   /// have been applied.

--- a/lib/src/models/show.dart
+++ b/lib/src/models/show.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Show {
   Show();
 
@@ -60,4 +60,6 @@ class Show {
   String uri;
 
   factory Show.fromJson(Map<String, dynamic> json) => _$ShowFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ShowToJson(this);
 }

--- a/lib/src/models/show.dart
+++ b/lib/src/models/show.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Show {
   Show();
 

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Track extends Object implements TrackSimple {
   Track();
 
@@ -119,7 +119,7 @@ class Track extends Object implements TrackSimple {
   String uri;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class TrackSimple extends Object {
   TrackSimple();
 
@@ -197,7 +197,7 @@ class TrackSimple extends Object {
 }
 
 /// A song saved in a Spotify user’s “Your Music” library
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class TrackSaved extends Object {
   TrackSaved();
   factory TrackSaved.fromJson(Map<String, dynamic> json) =>
@@ -213,7 +213,7 @@ class TrackSaved extends Object {
   Track track;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class TrackLink extends Object {
   TrackLink();
   factory TrackLink.fromJson(Map<String, dynamic> json) =>
@@ -238,7 +238,7 @@ class TrackLink extends Object {
   String uri;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class TracksLink extends Object {
   TracksLink();
   factory TracksLink.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -3,11 +3,13 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Track extends Object implements TrackSimple {
   Track();
 
   factory Track.fromJson(Map<String, dynamic> json) => _$TrackFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TrackToJson(this);
 
   /// The album on which the track appears. The album object includes a link
   /// in [href] to full information about the album.
@@ -117,12 +119,14 @@ class Track extends Object implements TrackSimple {
   String uri;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class TrackSimple extends Object {
   TrackSimple();
 
   factory TrackSimple.fromJson(Map<String, dynamic> json) =>
       _$TrackSimpleFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TrackSimpleToJson(this);
 
   /// The artists who performed the track. Each artist object includes a link
   /// in [href] to more detailed information about the artist.
@@ -193,11 +197,13 @@ class TrackSimple extends Object {
 }
 
 /// A song saved in a Spotify user’s “Your Music” library
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class TrackSaved extends Object {
   TrackSaved();
   factory TrackSaved.fromJson(Map<String, dynamic> json) =>
       _$TrackSavedFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TrackSavedToJson(this);
 
   /// The date and time the track was saved.
   @JsonKey(name: 'added_at')
@@ -207,11 +213,13 @@ class TrackSaved extends Object {
   Track track;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class TrackLink extends Object {
   TrackLink();
   factory TrackLink.fromJson(Map<String, dynamic> json) =>
       _$TrackLinkFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TrackLinkToJson(this);
 
   /// Known external URLs for this track.
   @JsonKey(name: 'external_urls')
@@ -230,11 +238,13 @@ class TrackLink extends Object {
   String uri;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class TracksLink extends Object {
   TracksLink();
   factory TracksLink.fromJson(Map<String, dynamic> json) =>
       _$TracksLinkFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TracksLinkToJson(this);
 
   /// A link to the Web API endpoint where full details of the playlist's
   /// tracks can be retrieved

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -3,10 +3,13 @@
 
 part of spotify.models;
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class User extends Object implements UserPublic {
   User();
+
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserToJson(this);
 
   /// The user's date-of-birth.
   ///
@@ -70,11 +73,14 @@ class User extends Object implements UserPublic {
   String uri;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class UserPublic extends Object {
   UserPublic();
+
   factory UserPublic.fromJson(Map<String, dynamic> json) =>
       _$UserPublicFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserPublicToJson(this);
 
   /// The name displayed on the user's profile. null if not available.
   @JsonKey(name: 'display_name')
@@ -103,11 +109,14 @@ class UserPublic extends Object {
   String uri;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class PlayHistory extends Object {
   PlayHistory();
+
   factory PlayHistory.fromJson(Map<String, dynamic> json) =>
       _$PlayHistoryFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PlayHistoryToJson(this);
 
   /// The track the user listened to.
   TrackSimple track;

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -3,7 +3,7 @@
 
 part of spotify.models;
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class User extends Object implements UserPublic {
   User();
 
@@ -73,7 +73,7 @@ class User extends Object implements UserPublic {
   String uri;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class UserPublic extends Object {
   UserPublic();
 
@@ -109,7 +109,7 @@ class UserPublic extends Object {
   String uri;
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class PlayHistory extends Object {
   PlayHistory();
 


### PR DESCRIPTION
### Purpose of the PR

Spotify models in this package are very useful and can be reusable by developers in theirs projects.

But in my opinion, the method `toJson` in missing.
In my case, I would like to store some informations in my database, and I need to serialize this spotify models.

With this PR, I add this `toJson` method for each model using `build_runner` and `json_serializable`.