### PR TITLE
Create a client using only an AccessToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## 0.5.2
-- add access-token only SpotifyApi constructor 
 ## 0.5.1
 
 - add createPlaylist optional parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.5.2
+- add access-token only SpotifyApi constructor 
 ## 0.5.1
 
 - add createPlaylist optional parameters

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ SpotifyApi api = SpotifyApi(spotifyCredentials, onCredentialsRefreshed: (Spotify
         });
 ``` 
 
+#### Access Token authentication
+In case you already have a valid access token and you don't need to complete any of the above flows you can use this constructor.
+
+```dart
+var spotify = SpotifyApi.withAccessToken(accessToken);
+```
+
+In that case, you are responsible of refreshing and updating the token accordingly.
+
 ## Features and bugs
 
 Please file feature requests and bugs at the [issue tracker][tracker].

--- a/lib/src/spotify.dart
+++ b/lib/src/spotify.dart
@@ -14,6 +14,9 @@ class SpotifyApi extends SpotifyApiBase {
       oauth2.AuthorizationCodeGrant grant, String responseUri)
       : super.fromAuthCodeGrant(grant, responseUri);
 
+  SpotifyApi.withAccessToken(String accessToken)
+      : super._withAccessToken(accessToken);
+
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
       SpotifyApiCredentials credentials, {Function(SpotifyApiCredentials) onCredentialsRefreshed}) {
     return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client(), onCredentialsRefreshed);

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -56,6 +56,9 @@ abstract class SpotifyApiBase {
   SpotifyApiBase.fromAuthCodeGrant(oauth2.AuthorizationCodeGrant grant, String responseUri)
       : this.fromClient(grant.handleAuthorizationResponse(Uri.parse(responseUri).queryParameters));
 
+  SpotifyApiBase._withAccessToken(String accessToken)
+      : this.fromClient(oauth2.Client(oauth2.Credentials(accessToken)));
+
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(SpotifyApiCredentials credentials, http.BaseClient httpClient,
       [Function(SpotifyApiCredentials) callBack]) {
     if (callBack == null)

--- a/lib/src/spotify_credentials.dart
+++ b/lib/src/spotify_credentials.dart
@@ -51,6 +51,8 @@ class SpotifyApiCredentials {
     this.expiration,
   }) : tokenEndpoint = Uri.parse(SpotifyApiBase._tokenUrl);
 
+  SpotifyApiCredentials.withAccessToken(this.accessToken);
+
   SpotifyApiCredentials._fromClient(oauth2.Client client) {
     clientId = client.identifier;
     clientSecret = client.secret;


### PR DESCRIPTION
Addresses https://github.com/rinukkusu/spotify-dart/issues/70 by adding a new constructor that only requires a valid access token.