### PR TITLE
Add support to add a track to a playlist at the desired position.

### DIFF
--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -60,8 +60,14 @@ class Playlists extends EndpointPaging {
   /// [trackUri] - the Spotify track uri (i.e spotify:track:4iV5W9uYEdYUVa79Axb7Rh)
   ///
   /// [playlistId] - the playlist ID
-  Future<Null> addTrack(String trackUri, String playlistId) async {
-    final url = 'v1/playlists/$playlistId/tracks';
+  Future<Null> addTrack(String trackUri, String playlistId,
+      {int position = -1}) async {
+    String url = 'v1/playlists/$playlistId/tracks';
+
+    if (position >= 0) {
+      url = url + "?position=" + position.toString();
+    }
+
     await _api._post(
         url,
         jsonEncode({


### PR DESCRIPTION
I have a use case where I want to add a track to a playlist at a specific location. 

By default, tracks are added to the end of the playlist. This PR adds an option "position" property property which, if provided, is appended to the URL sent to Spotify.