### PR TITLE
Added static async factory to SpotifyApi to catch exceptions thrown by oauth2 package

### DIFF
--- a/example/example_async.dart
+++ b/example/example_async.dart
@@ -1,0 +1,20 @@
+import 'package:spotify/spotify.dart';
+
+void main() async {
+  var credentials = SpotifyApiCredentials(
+    'clientId',
+    'clientSecret',
+  );
+
+  try {
+    var spotify = await SpotifyApi.asyncFromCredentials(credentials);
+    var search = await spotify.search.get(
+      'Against The Current - weapon',
+      types: [SearchType.track],
+    ).first(1);
+
+    print(search);
+  } on AuthorizationException {
+    print('Invalid credentials!');
+  }
+}

--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -5,31 +5,34 @@ library spotify;
 
 import 'dart:async';
 import 'dart:convert';
-import 'package:pedantic/pedantic.dart';
+
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
+import 'package:pedantic/pedantic.dart';
 import 'package:spotify/spotify_browser.dart';
 
 import 'src/models/_models.dart';
 
+export 'package:oauth2/oauth2.dart'
+    show AuthorizationException, ExpirationException;
+
 export 'src/models/_models.dart';
 
-part 'src/endpoints/endpoint_base.dart';
-part 'src/endpoints/endpoint_paging.dart';
-part 'src/endpoints/artists.dart';
 part 'src/endpoints/albums.dart';
-part 'src/endpoints/tracks.dart';
-part 'src/endpoints/playlists.dart';
-part 'src/endpoints/recommendations.dart';
-part 'src/endpoints/users.dart';
-part 'src/endpoints/search.dart';
+part 'src/endpoints/artists.dart';
 part 'src/endpoints/audio_features.dart';
 part 'src/endpoints/categories.dart';
-part 'src/endpoints/shows.dart';
+part 'src/endpoints/endpoint_base.dart';
+part 'src/endpoints/endpoint_paging.dart';
 part 'src/endpoints/me.dart';
-
-part 'src/spotify_credentials.dart';
+part 'src/endpoints/playlists.dart';
+part 'src/endpoints/recommendations.dart';
+part 'src/endpoints/search.dart';
+part 'src/endpoints/shows.dart';
+part 'src/endpoints/tracks.dart';
+part 'src/endpoints/users.dart';
+part 'src/spotify.dart';
 part 'src/spotify_base.dart';
+part 'src/spotify_credentials.dart';
 part 'src/spotify_exception.dart';
 part 'src/utils.dart';
-part 'src/spotify.dart';

--- a/lib/src/spotify.dart
+++ b/lib/src/spotify.dart
@@ -18,6 +18,17 @@ class SpotifyApi extends SpotifyApiBase {
   SpotifyApi.withAccessToken(String accessToken)
       : super._withAccessToken(accessToken);
 
+  static Future<SpotifyApi> asyncFromCredentials(
+    SpotifyApiCredentials credentials, {
+    Function(SpotifyApiCredentials)? onCredentialsRefreshed,
+  }) {
+    return SpotifyApiBase._asyncFromCredentials(
+      credentials,
+      http.Client(),
+      onCredentialsRefreshed,
+    );
+  }
+
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
       SpotifyApiCredentials credentials,
       {Function(SpotifyApiCredentials)? onCredentialsRefreshed}) {

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -63,16 +63,31 @@ abstract class SpotifyApiBase {
   SpotifyApiBase._withAccessToken(String accessToken)
       : this.fromClient(oauth2.Client(oauth2.Credentials(accessToken)));
 
+  static Future<SpotifyApi> _asyncFromCredentials(
+    SpotifyApiCredentials credentials, [
+    http.Client? httpClient,
+    Function(SpotifyApiCredentials)? callBack,
+  ]) async {
+    final client = await _getOauth2Client(
+      credentials,
+      httpClient,
+      callBack,
+    );
+
+    return SpotifyApi.fromClient(client);
+  }
+
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
       SpotifyApiCredentials credentials, http.Client httpClient,
       [Function(SpotifyApiCredentials)? callBack]) {
-    if (callBack == null)
+    if (callBack == null) {
       return oauth2.AuthorizationCodeGrant(
           credentials.clientId!,
           Uri.parse(SpotifyApiBase._authorizationUrl),
           Uri.parse(SpotifyApiBase._tokenUrl),
           secret: credentials.clientSecret,
           httpClient: httpClient);
+    }
 
     return oauth2.AuthorizationCodeGrant(
         credentials.clientId!,
@@ -81,7 +96,7 @@ abstract class SpotifyApiBase {
         secret: credentials.clientSecret,
         httpClient: httpClient,
         onCredentialsRefreshed: (oauth2.Credentials cred) {
-      SpotifyApiCredentials newCredentials = SpotifyApiCredentials(
+      var newCredentials = SpotifyApiCredentials(
           credentials.clientId, credentials.clientSecret,
           accessToken: cred.accessToken,
           expiration: cred.expiration,
@@ -111,7 +126,7 @@ abstract class SpotifyApiBase {
         onCredentialsRefreshed: callBack == null
             ? null
             : (oauth2.Credentials cred) {
-                SpotifyApiCredentials newCredentials = SpotifyApiCredentials(
+                var newCredentials = SpotifyApiCredentials(
                     credentials.clientId, credentials.clientSecret,
                     accessToken: cred.accessToken,
                     expiration: cred.expiration,
@@ -132,19 +147,19 @@ abstract class SpotifyApiBase {
   }
 
   Future<String> _get(String path) {
-    return _getImpl('${_baseUrl}/$path', const {});
+    return _getImpl('$_baseUrl/$path', const {});
   }
 
   Future<String> _post(String path, [String body = '']) {
-    return _postImpl('${_baseUrl}/$path', const {}, body);
+    return _postImpl('$_baseUrl/$path', const {}, body);
   }
 
   Future<String> _delete(String path, [String body = '']) {
-    return _deleteImpl('${_baseUrl}/$path', const {}, body);
+    return _deleteImpl('$_baseUrl/$path', const {}, body);
   }
 
   Future<String> _put(String path, [String body = '']) {
-    return _putImpl('${_baseUrl}/$path', const {}, body);
+    return _putImpl('$_baseUrl/$path', const {}, body);
   }
 
   Future<String> _getImpl(String url, Map<String, String> headers) async {
@@ -196,7 +211,7 @@ abstract class SpotifyApiBase {
   }
 
   Future<SpotifyApiCredentials> getCredentials() async {
-    return await SpotifyApiCredentials._fromClient(await _client);
+    return SpotifyApiCredentials._fromClient(await _client);
   }
 
   String handleErrors(http.Response response) {


### PR DESCRIPTION
Right now the only way to instantiate SpotifyApi class with credentials is like this:
```dart
var credentials = SpotifyApiCredentials(
  'clientId',
  'clientSecret',
);
var spotify = SpotifyApi(credentials);
```

But with wrong credentials you get AuthorizationException, which you can't catch with any obvious way (and probably can't catch without modifying the library itself at all)
```dart
try {
  var spotify = SpotifyApi(invalidCredentials);
} on AuthorizationException {
  print('This will never print despite the exception being thrown');
}
```

That is because `_getOauth2Client` method never gets awaited and is instantly used in class.
https://github.com/rinukkusu/spotify-dart/blob/7af8323ebe3831fac1ac8beb72aa5c991728f827/lib/src/spotify_base.dart#L54-L56

However, this PR allows instantiating SpotifyApi asynchronously with static method `asyncFromCredentials`, meaning that exceptions can be handled in `<Future>.catchError` or a try/catch block.
```dart
try {
  var spotify = await SpotifyApi.asyncFromCredentials(invalidCredentials);
} on AuthorizationException {
  print('Invalid credentials!');
}
```

I also added export from oauth2 package exposing `AuthorizationException` and `ExpirationException` so these can be handled

Might resolve #73 