### PR TITLE
Implements the `browse/new-releases` endpoint

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -13,16 +13,16 @@ void main() async {
   var spotify = SpotifyApi(credentials);
 
   print('\nPodcast:');
-  await spotify.shows.get('4rOoJ6Egrf8K2IrywzwOMk')
+  await spotify.shows
+      .get('4rOoJ6Egrf8K2IrywzwOMk')
       .then((podcast) => print(podcast.name))
-      .onError((error, stackTrace) => print((error as SpotifyException).message));
+      .onError(
+          (error, stackTrace) => print((error as SpotifyException).message));
 
   print('\nPodcast episode:');
   var episodes = spotify.shows.episodes('4AlxqGkkrqe0mfIx3Mi7Xt');
-  await episodes.first()
-      .then((first) => print(first.items!.first))
-      .onError((error, stackTrace) => print((error as SpotifyException).message));
-
+  await episodes.first().then((first) => print(first.items!.first)).onError(
+      (error, stackTrace) => print((error as SpotifyException).message));
 
   print('\nArtists:');
   var artists = await spotify.artists.list(['0OdUWJ0sBjDrqHygGUXeCF']);
@@ -38,6 +38,10 @@ void main() async {
     print(track.name);
   });
 
+  print('\nNew Releases');
+  var newReleases = await spotify.browse.getNewReleasess().first();
+  newReleases.items!.forEach((album) => print(album.name));
+
   print('\nFeatured Playlist:');
   var featuredPlaylists = await spotify.playlists.featured.all();
   featuredPlaylists.forEach((playlist) {
@@ -45,7 +49,8 @@ void main() async {
   });
 
   print('\nUser\'s playlists:');
-  var usersPlaylists = await spotify.playlists.getUsersPlaylists('superinteressante').all();
+  var usersPlaylists =
+      await spotify.playlists.getUsersPlaylists('superinteressante').all();
   usersPlaylists.forEach((playlist) {
     print(playlist.name);
   });

--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -21,6 +21,7 @@ export 'src/models/_models.dart';
 part 'src/endpoints/albums.dart';
 part 'src/endpoints/artists.dart';
 part 'src/endpoints/audio_features.dart';
+part 'src/endpoints/browse.dart';
 part 'src/endpoints/categories.dart';
 part 'src/endpoints/endpoint_base.dart';
 part 'src/endpoints/endpoint_paging.dart';

--- a/lib/src/endpoints/browse.dart
+++ b/lib/src/endpoints/browse.dart
@@ -1,0 +1,21 @@
+part of spotify;
+
+class Browse extends EndpointPaging {
+  Browse(SpotifyApiBase api) : super(api);
+
+  @override
+  String get _path => 'v1/browse';
+
+  /// Returns the new releases.
+  ///
+  /// [country] - a country: an ISO 3166-1 alpha-2 country code. Provide this
+  /// parameter if you want to narrow the list of returned new releases to those
+  /// relevant to a particular country. If omitted, the returned items will be
+  /// globally relevant.
+  Pages<AlbumSimple> getNewReleasess({String? country}) {
+    var params = _buildQuery({'country': country});
+
+    return _getPages('$_path/new-releases?$params', (json) => AlbumSimple.fromJson(json),
+        'albums', (json) => AlbumSimple.fromJson(json));
+  }
+}

--- a/lib/src/endpoints/categories.dart
+++ b/lib/src/endpoints/categories.dart
@@ -1,8 +1,9 @@
 part of spotify;
 
-class Categories extends EndpointPaging {
+class Categories extends Browse {
+  
   @override
-  String get _path => 'v1/browse/categories';
+  String get _path => '${super._path}/categories';
 
   Categories(SpotifyApiBase api) : super(api);
 

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -15,6 +15,8 @@ abstract class SpotifyApiBase {
   Artists get artists => _artists;
   late Albums _albums;
   Albums get albums => _albums;
+  late Browse _browse;
+  Browse get browse => _browse;
   late Tracks _tracks;
   Tracks get tracks => _tracks;
   late Playlists _playlists;
@@ -40,6 +42,7 @@ abstract class SpotifyApiBase {
 
     _artists = Artists(this);
     _albums = Albums(this);
+    _browse = Browse(this);
     _tracks = Tracks(this);
     _playlists = Playlists(this);
     _recommendations = RecommendationsEndpoint(this);

--- a/lib/src/spotify_mock.dart
+++ b/lib/src/spotify_mock.dart
@@ -39,8 +39,8 @@ class MockClient implements oauth2.Client {
 
   String _readPath(String url) {
     var regexString = url.contains('api.spotify.com')
-        ? r'api.spotify.com\/([A-Za-z0-9/]+)\??'
-        : r'api/([A-Za-z0-9/]+)\??';
+        ? r'api.spotify.com\/([A-Za-z0-9/\-]+)\??'
+        : r'api/([A-Za-z0-9/\-]+)\??';
 
     var regex = RegExp(regexString);
     var partialPath = regex.firstMatch(url)!.group(1);

--- a/test/data/v1/browse/new-releases.json
+++ b/test/data/v1/browse/new-releases.json
@@ -1,0 +1,131 @@
+{
+  "albums" : {
+    "href" : "https://api.spotify.com/v1/browse/new-releases?country=DE&offset=0&limit=20",
+    "items" : [ {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3utZ2yeQk0Z3BCOBWP7Vlu"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3utZ2yeQk0Z3BCOBWP7Vlu",
+        "id" : "3utZ2yeQk0Z3BCOBWP7Vlu",
+        "name" : "CRO",
+        "type" : "artist",
+        "uri" : "spotify:artist:3utZ2yeQk0Z3BCOBWP7Vlu"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/50MeziN5Do8zDtN4wINTTS"
+      },
+      "href" : "https://api.spotify.com/v1/albums/50MeziN5Do8zDtN4wINTTS",
+      "id" : "50MeziN5Do8zDtN4wINTTS",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273fc1e217bd475c240b49a2f1e",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02fc1e217bd475c240b49a2f1e",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851fc1e217bd475c240b49a2f1e",
+        "width" : 64
+      } ],
+      "name" : "11:11",
+      "release_date" : "2022-08-11",
+      "release_date_precision" : "day",
+      "total_tracks" : 12,
+      "type" : "album",
+      "uri" : "spotify:album:50MeziN5Do8zDtN4wINTTS"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2wVqIfYWtTq2JTm6f9WRwM"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2wVqIfYWtTq2JTm6f9WRwM",
+        "id" : "2wVqIfYWtTq2JTm6f9WRwM",
+        "name" : "No Skool",
+        "type" : "artist",
+        "uri" : "spotify:artist:2wVqIfYWtTq2JTm6f9WRwM"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/78TTCmh2koperK5NBn7DgR"
+        },
+        "href" : "https://api.spotify.com/v1/artists/78TTCmh2koperK5NBn7DgR",
+        "id" : "78TTCmh2koperK5NBn7DgR",
+        "name" : "102 Boyz",
+        "type" : "artist",
+        "uri" : "spotify:artist:78TTCmh2koperK5NBn7DgR"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/1ZECRSxRgZHno2V4Fat7CZ"
+      },
+      "href" : "https://api.spotify.com/v1/albums/1ZECRSxRgZHno2V4Fat7CZ",
+      "id" : "1ZECRSxRgZHno2V4Fat7CZ",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2737b431b34601b69efd89e86dd",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e027b431b34601b69efd89e86dd",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048517b431b34601b69efd89e86dd",
+        "width" : 64
+      } ],
+      "name" : "No Skool",
+      "release_date" : "2022-08-11",
+      "release_date_precision" : "day",
+      "total_tracks" : 12,
+      "type" : "album",
+      "uri" : "spotify:album:1ZECRSxRgZHno2V4Fat7CZ"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/181bsRPaVXVlUKXrxwZfHK"
+        },
+        "href" : "https://api.spotify.com/v1/artists/181bsRPaVXVlUKXrxwZfHK",
+        "id" : "181bsRPaVXVlUKXrxwZfHK",
+        "name" : "Megan Thee Stallion",
+        "type" : "artist",
+        "uri" : "spotify:artist:181bsRPaVXVlUKXrxwZfHK"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/4YP0h2KGDb20eJuStnBvim"
+      },
+      "href" : "https://api.spotify.com/v1/albums/4YP0h2KGDb20eJuStnBvim",
+      "id" : "4YP0h2KGDb20eJuStnBvim",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2731182d680c2894b4e0f39033e",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e021182d680c2894b4e0f39033e",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048511182d680c2894b4e0f39033e",
+        "width" : 64
+      } ],
+      "name" : "Traumazine",
+      "release_date" : "2022-08-12",
+      "release_date_precision" : "day",
+      "total_tracks" : 18,
+      "type" : "album",
+      "uri" : "spotify:album:4YP0h2KGDb20eJuStnBvim"
+    } ],
+    "limit" : 20,
+    "next" : "https://api.spotify.com/v1/browse/new-releases?country=DE&offset=20&limit=20",
+    "offset" : 0,
+    "previous" : null,
+    "total" : 100
+  }
+}

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -90,6 +90,19 @@ Future main() async {
     });
   });
 
+  group('Browse', () {
+    test('Get New Releases', () async {
+      var newReleases = spotify.browse.getNewReleasess();
+      var firstPage = await newReleases.first();
+      expect(firstPage.items!.length, 3);
+
+      var firstItem = firstPage.items!.first;
+      expect(firstItem.id, '50MeziN5Do8zDtN4wINTTS');
+      expect(firstItem.name, '11:11');
+      expect(firstItem.releaseDate, '2022-08-11');
+    });
+  });
+
   group('Playlists', () {
     test('getUsersPlaylists', () async {
       var playlists = spotify.playlists.getUsersPlaylists('X123Y');


### PR DESCRIPTION
This PR adds the `browse/new-releases` endpoint. 

Since browsing categories in [`categories.dart`](lib/src/endpoints/categories.dart) and browsing new releases share the same `v1/browse/` api-path, I let the class `Categories` inherit from the `Browse` class:

![](http://www.plantuml.com/plantuml/img/SoWkIImgAStDuU9oAielBqvLiAdHrLLmJYn9JSyloamjvd98pKi1oGC0)

What do you guys think of this approach?
After looking into the code, I figured, that the `Playlist` class shares the same `v1/browse` `_path` like in the `Browse` class, although it is only used twice in `Playlist` (one in `featured` and one `byCategoryId()`). I wonder, if we should clean this up and figure a proper model of the library. Maybe an Issue regarding this topic should be discussed. Or we get rid of the `Browse` class completely and put the `new-realeases` somewhere else. 