### PR TITLE
Add extended support for me.topArtists & me.topTracks endpoints

### DIFF
--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -89,8 +89,8 @@ class Me extends EndpointPaging {
   }
 
   /// Get the current user's top artists.
-  Future<Iterable<Artist>> topArtists() async {
-    final jsonString = await _api._get('$_path/top/artists');
+  Future<Iterable<Artist>> topArtists(int limit, String timeRange) async {
+    final jsonString = await _api._get('$_path/top/artists?time_range=$timeRange&limit=$limit');
     final map = json.decode(jsonString);
 
     final items = map['items'] as Iterable<dynamic>;

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -80,8 +80,12 @@ class Me extends EndpointPaging {
   }
 
   /// Get the current user's top tracks.
-  Future<Iterable<Track>> topTracks() async {
-    final jsonString = await _api._get('$_path/top/tracks');
+  /// @param limit: the maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.
+  /// @param offset: The index of the first item to return. Default: 0 (the first item). Use with limit to get the next set of items.
+  /// @param time_range: Over what time frame the affinities are computed (long_term, medium_term, short_term)
+  /// For more information, see https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks
+  Future<Iterable<Track>> topTracks(int limit, int offset, String timeRange) async {
+    final jsonString = await _api._get('$_path/top/tracks?time_range=$timeRange&limit=$limit&offset=$offset');
     final map = json.decode(jsonString);
 
     final items = map['items'] as Iterable<dynamic>;
@@ -89,8 +93,12 @@ class Me extends EndpointPaging {
   }
 
   /// Get the current user's top artists.
-  Future<Iterable<Artist>> topArtists(int limit, String timeRange) async {
-    final jsonString = await _api._get('$_path/top/artists?time_range=$timeRange&limit=$limit');
+  /// @param limit: the maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.
+  /// @param offset: The index of the first item to return. Default: 0 (the first item). Use with limit to get the next set of items.
+  /// @param time_range: Over what time frame the affinities are computed (long_term, medium_term, short_term)
+  /// For more information See https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks
+  Future<Iterable<Artist>> topArtists(int limit, int offset, String timeRange) async {
+    final jsonString = await _api._get('$_path/top/artists?time_range=$timeRange&limit=$limit&offset=$offset');
     final map = json.decode(jsonString);
 
     final items = map['items'] as Iterable<dynamic>;

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -23,7 +23,7 @@ class Users extends EndpointPaging {
   CursorPages<PlayHistory> recentlyPlayed() => _me.recentlyPlayed();
 
   @Deprecated('Use "SpotifyApi.me.topTracks()"')
-  Future<Iterable<Track>> topTracks() => _me.topTracks();
+  Future<Iterable<Track>> topTracks() => _me.topTracks(20, 0, "medium_term");
 
   @Deprecated('Use "SpotifyApi.me.devices()"')
   Future<Iterable<Device>> devices() async => _me.devices();


### PR DESCRIPTION
Hello !
I am currently using this really useful lib in a flutter project around the spotify API, thanks !
However, features are really limited when we want to retrieve users' top items because we could not use specific values for the parameters stated here (limit, offset & time_range) :
https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks

Hence, I did simple modifications to the functions `me.topArtists()` and `me.topTracks()` so that I could use them in my project :)

Here is the detail of my modifications :
- Add support to use specific values for the parameters ""limit", "offset", & "time_range"
- Add comments to explain the use of the functions with a reference to the Spotify Web API endpoint documentation (Get User's Top Items)
- Modify the call of the `me.topTracks() `endpoint in the deprecated function `users.topTracks()`