### PR TITLE
Refactors player methods from `me`

### DIFF
--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -67,7 +67,7 @@ Future<SpotifyApi?> _getUserAuthenticatedSpotifyApi(
 }
 
 Future<void> _currentlyPlaying(SpotifyApi spotify) async =>
-    await spotify.me.currentlyPlaying().then((Player? a) {
+    await spotify.player.currentlyPlaying().then((Player? a) {
       if (a?.item == null) {
         print('Nothing currently playing.');
         return;
@@ -100,7 +100,7 @@ Future<void> _user(SpotifyApi spotify) async {
 }
 
 Future<void> _devices(SpotifyApi spotify) async =>
-    await spotify.me.devices().then((Iterable<Device>? devices) {
+    await spotify.player.devices().then((Iterable<Device>? devices) {
       if (devices == null || devices.isEmpty) {
         print('No devices currently playing.');
         return;
@@ -117,7 +117,7 @@ Future<void> _followingArtists(SpotifyApi spotify) async {
 }
 
 Future<void> _shuffle(bool state, SpotifyApi spotify) async {
-  await spotify.me.shuffle(state).then((player) {
+  await spotify.player.shuffle(state).then((player) {
     print('Shuffle: ${player.isShuffling}');
   }).catchError((ex) => _prettyPrintError(ex));
 }

--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -26,6 +26,7 @@ part 'src/endpoints/categories.dart';
 part 'src/endpoints/endpoint_base.dart';
 part 'src/endpoints/endpoint_paging.dart';
 part 'src/endpoints/me.dart';
+part 'src/endpoints/player.dart';
 part 'src/endpoints/playlists.dart';
 part 'src/endpoints/recommendations.dart';
 part 'src/endpoints/search.dart';

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -122,7 +122,7 @@ class Me extends MeEndpointBase {
   }
 
   /// Get information about a user’s available devices.
-  @Deprecated('Use [spotify.player.deviced()]')
+  @Deprecated('Use [spotify.player.devices()]')
   Future<Iterable<Device>> devices() async => _player.devices();
 
   /// Get a list of shows saved in the current Spotify user’s library.

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -4,7 +4,6 @@
 part of spotify;
 
 abstract class MeEndpointBase extends EndpointPaging {
-
   @override
   String get _path => 'v1/me';
 
@@ -12,8 +11,11 @@ abstract class MeEndpointBase extends EndpointPaging {
 }
 
 class Me extends MeEndpointBase {
+  late PlayerEndpoint _player;
 
-  Me(SpotifyApiBase api) : super(api);
+  Me(SpotifyApiBase api, PlayerEndpoint player) : super(api) {
+    _player = player;
+  }
 
   Future<User> get() async {
     final jsonString = await _api._get(_path);
@@ -59,7 +61,17 @@ class Me extends MeEndpointBase {
         ._delete("$_path/following?type=${type.key}&ids=${ids.join(",")}");
   }
 
-  
+  /// Get the object currently being played on the user’s Spotify account.
+  @Deprecated('Use [spotify.player.currentlyPlaying()]')
+  Future<Player> currentlyPlaying() async => _player.currentlyPlaying();
+
+  // Get the currently playing as well as the queued objects.
+  @Deprecated('Use [spotify.player.queue()]')
+  Future<Queue> queue() async => _player.queue();
+
+  // Add an object to the queue with a trackId.
+  @Deprecated('Use [spotify.player.addToQueue()]')
+  Future<void> addToQueue(String trackId) async => _player.addToQueue(trackId);
 
   /// Get tracks from the current user’s recently played tracks.
   /// Note: Currently doesn’t support podcast episodes.
@@ -78,6 +90,19 @@ class Me extends MeEndpointBase {
         (json) => PlayHistory.fromJson(json));
   }
 
+  /// Toggle Shuffle For User's Playback.
+  ///
+  /// Use [state] to toggle the shuffle. [true] to turn shuffle on and [false]
+  /// to turn it off respectively.
+  /// Returns the current player state by making another request.
+  /// See [player([String market])];
+  @Deprecated('Use [spotify.player.shuffle()]')
+  Future<Player> shuffle(bool state, [String? deviceId]) async => _player.shuffle(state, deviceId);
+
+  @Deprecated('Use [spotify.player.playbackState()]')
+  Future<Player> player([String? market]) async =>
+      _player.playbackState(market);
+
   /// Get the current user's top tracks.
   Future<Iterable<Track>> topTracks() async {
     final jsonString = await _api._get('$_path/top/tracks');
@@ -95,6 +120,10 @@ class Me extends MeEndpointBase {
     final items = map['items'] as Iterable<dynamic>;
     return items.map((item) => Artist.fromJson(item));
   }
+
+  /// Get information about a user’s available devices.
+  @Deprecated('Use [spotify.player.deviced()]')
+  Future<Iterable<Device>> devices() async => _player.devices();
 
   /// Get a list of shows saved in the current Spotify user’s library.
   Pages<Show> savedShows() {

--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2022, 2023, chances, rinukkusu, hayribakici. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+part of spotify;
+
+class PlayerEndpoint extends MeEndpointBase {
+  @override
+  String get _path => '${super._path}/player';
+
+  PlayerEndpoint(SpotifyApiBase api) : super(api);
+
+  /// Toggle Shuffle For User's Playback.
+  ///
+  /// Use [state] to toggle the shuffle. [true] to turn shuffle on and [false]
+  /// to turn it off respectively.
+  /// 
+  /// Returns the current player state by making another request.
+  /// See [playbackState([String market])];
+  Future<Player> shuffle(bool state, [String? deviceId]) async {
+    return _api._put('$_path/shuffle?' + _buildQuery({
+                    'state': state,
+                    'deviceId': deviceId})).then(playbackState);
+  }
+
+  /// Returns the current playback state, including progress, track
+  /// and active device.
+  @Deprecated('Use [playbackState] instead')
+  Future<Player> player([String? market]) async {
+    return playbackState(market);
+  }
+
+  /// Returns the current playback state, including progress, track
+  /// and active device.
+  Future<Player> playbackState([String? market]) async {
+    var jsonString =
+        await _api._get('$_path?' + _buildQuery({'market': market}));
+    final map = json.decode(jsonString);
+    return Player.fromJson(map);
+  }
+
+  /// Get the object currently being played on the user’s Spotify account.
+  Future<Player> currentlyPlaying() async {
+    final jsonString = await _api._get('$_path/currently-playing');
+
+    if (jsonString.isEmpty) {
+      return Player();
+    }
+
+    return Player.fromJson(json.decode(jsonString));
+  }
+
+  // Get the currently playing as well as the queued objects.
+  Future<Queue> queue() async {
+    final jsonString = await _api._get('$_path/queue');
+
+    if (jsonString.isEmpty) {
+      return Queue();
+    }
+
+    final map = json.decode(jsonString);
+    return Queue.fromJson(map);
+  }
+
+  // Add an object to the queue with a trackId.
+  Future<void> addToQueue(String trackId) async {
+    await _api._post('$_path/queue?uri=$trackId');
+  }
+
+  /// Get information about a user’s available devices.
+  Future<Iterable<Device>> devices() async {
+    return _api._get('$_path/devices').then(_parseDeviceJson);
+  }
+
+  Iterable<Device> _parseDeviceJson(String jsonString) {
+    final map = json.decode(jsonString);
+
+    final items = map['devices'] as Iterable<dynamic>;
+    return items.map((item) => Device.fromJson(item));
+  }
+}

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -4,31 +4,11 @@
 part of spotify;
 
 class Users extends EndpointPaging {
+
   @override
   String get _path => 'v1/users';
 
-  late Me _me;
-  late PlayerEndpoint _player;
-
-  Users(SpotifyApiBase api, Me me, PlayerEndpoint player) : super(api) {
-    _me = me;
-    _player = player;
-  }
-
-  @Deprecated('Use "SpotifyApi.me.get()"')
-  Future<User> me() => _me.get();
-
-  @Deprecated('Use "SpotifyApi.player.currentlyPlaying()"')
-  Future<Player> currentlyPlaying() => _player.currentlyPlaying();
-
-  @Deprecated('Use "SpotifyApi.me.recentlyPlayed()"')
-  CursorPages<PlayHistory> recentlyPlayed() => _me.recentlyPlayed();
-
-  @Deprecated('Use "SpotifyApi.me.topTracks()"')
-  Future<Iterable<Track>> topTracks() => _me.topTracks();
-
-  @Deprecated('Use "SpotifyApi.player.devices()"')
-  Future<Iterable<Device>> devices() async => _player.devices();
+  Users(SpotifyApiBase api) : super(api);
 
   Future<UserPublic> get(String userId) async {
     var jsonString = await _api._get('$_path/$userId');

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -8,16 +8,18 @@ class Users extends EndpointPaging {
   String get _path => 'v1/users';
 
   late Me _me;
+  late PlayerEndpoint _player;
 
-  Users(SpotifyApiBase api, Me me) : super(api) {
+  Users(SpotifyApiBase api, Me me, PlayerEndpoint player) : super(api) {
     _me = me;
+    _player = player;
   }
 
   @Deprecated('Use "SpotifyApi.me.get()"')
   Future<User> me() => _me.get();
 
-  @Deprecated('Use "SpotifyApi.me.currentlyPlaying()"')
-  Future<Player> currentlyPlaying() => _me.currentlyPlaying();
+  @Deprecated('Use "SpotifyApi.player.currentlyPlaying()"')
+  Future<Player> currentlyPlaying() => _player.currentlyPlaying();
 
   @Deprecated('Use "SpotifyApi.me.recentlyPlayed()"')
   CursorPages<PlayHistory> recentlyPlayed() => _me.recentlyPlayed();
@@ -25,8 +27,8 @@ class Users extends EndpointPaging {
   @Deprecated('Use "SpotifyApi.me.topTracks()"')
   Future<Iterable<Track>> topTracks() => _me.topTracks();
 
-  @Deprecated('Use "SpotifyApi.me.devices()"')
-  Future<Iterable<Device>> devices() async => _me.devices();
+  @Deprecated('Use "SpotifyApi.player.devices()"')
+  Future<Iterable<Device>> devices() async => _player.devices();
 
   Future<UserPublic> get(String userId) async {
     var jsonString = await _api._get('$_path/$userId');

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -48,8 +48,8 @@ abstract class SpotifyApiBase {
     _tracks = Tracks(this);
     _playlists = Playlists(this);
     _recommendations = RecommendationsEndpoint(this);
-    _me = Me(this);
     _player = PlayerEndpoint(this);
+    _me = Me(this, _player);
     _users = Users(this, _me, _player);
     _search = Search(this);
     _audioFeatures = AudioFeatures(this);

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -50,7 +50,7 @@ abstract class SpotifyApiBase {
     _recommendations = RecommendationsEndpoint(this);
     _player = PlayerEndpoint(this);
     _me = Me(this, _player);
-    _users = Users(this, _me, _player);
+    _users = Users(this);
     _search = Search(this);
     _audioFeatures = AudioFeatures(this);
     _categories = Categories(this);

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -33,6 +33,8 @@ abstract class SpotifyApiBase {
   Categories get categories => _categories;
   late Me _me;
   Me get me => _me;
+  late PlayerEndpoint _player;
+  PlayerEndpoint get player => _player;
   late Shows _shows;
   Shows get shows => _shows;
   FutureOr<oauth2.Client> get client => _client;
@@ -47,7 +49,8 @@ abstract class SpotifyApiBase {
     _playlists = Playlists(this);
     _recommendations = RecommendationsEndpoint(this);
     _me = Me(this);
-    _users = Users(this, _me);
+    _player = PlayerEndpoint(this);
+    _users = Users(this, _me, _player);
     _search = Search(this);
     _audioFeatures = AudioFeatures(this);
     _categories = Categories(this);

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -169,13 +169,13 @@ Future main() async {
 
   group('User', () {
     test('currentlyPlaying', () async {
-      var result = await spotify.me.currentlyPlaying();
+      var result = await spotify.player.currentlyPlaying();
 
       expect(result.item!.name, 'As I Am');
     });
 
     test('devices', () async {
-      var result = await spotify.me.devices();
+      var result = await spotify.player.devices();
       expect(result.length, 1);
       expect(result.first.id, '5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e');
       expect(result.first.isActive, true);
@@ -209,7 +209,7 @@ Future main() async {
     });
 
     test('getQueue', () async {
-      var result = await spotify.me.queue();
+      var result = await spotify.player.queue();
       final currentlyPlaying = result.currentlyPlaying;
       final queue = result.queue;
 
@@ -293,7 +293,7 @@ Future main() async {
 
   group('Player', () {
     test('player', () async {
-      var result = await spotify.me.player();
+      var result = await spotify.player.playbackState();
       expect(result.isShuffling, true);
       expect(result.isPlaying, true);
       expect(result.currentlyPlayingType, CurrentlyPlayingType.track);


### PR DESCRIPTION
This PR fixes #139. 

It furthermore depracates the following methods in `Me` as they have been moved to the new `PlayerEndpoint` class:

* `queue`
* `addToQueue`
* `devices`
* `player`
* `shuffle`

