### PR TITLE
Add player methods for controlling playback (#134)

### DIFF
--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -63,7 +63,7 @@ class Me extends MeEndpointBase {
 
   /// Get the object currently being played on the user’s Spotify account.
   @Deprecated('Use [spotify.player.currentlyPlaying()]')
-  Future<Player> currentlyPlaying() async => _player.currentlyPlaying();
+  Future<PlaybackState> currentlyPlaying() async => _player.currentlyPlaying();
 
   // Get the currently playing as well as the queued objects.
   @Deprecated('Use [spotify.player.queue()]')
@@ -97,10 +97,11 @@ class Me extends MeEndpointBase {
   /// Returns the current player state by making another request.
   /// See [player([String market])];
   @Deprecated('Use [spotify.player.shuffle()]')
-  Future<Player> shuffle(bool state, [String? deviceId]) async => _player.shuffle(state, deviceId);
+  Future<PlaybackState> shuffle(bool state, [String? deviceId]) async =>
+      _player.shuffle(state, deviceId);
 
   @Deprecated('Use [spotify.player.playbackState()]')
-  Future<Player> player([String? market]) async =>
+  Future<PlaybackState> player([String? market]) async =>
       _player.playbackState(market);
 
   /// Get the current user's top tracks.

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -97,8 +97,8 @@ class Me extends MeEndpointBase {
   /// Returns the current player state by making another request.
   /// See [player([String market])];
   @Deprecated('Use [spotify.player.shuffle()]')
-  Future<PlaybackState> shuffle(bool state, [String? deviceId]) async =>
-      _player.shuffle(state, deviceId);
+  Future<PlaybackState?> shuffle(bool state, [String? deviceId]) async =>
+      _player.shuffle(state, deviceId: deviceId);
 
   @Deprecated('Use [spotify.player.playbackState()]')
   Future<PlaybackState> player([String? market]) async =>

--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -13,14 +13,14 @@ class PlayerEndpoint extends MeEndpointBase {
   ///
   /// Use [state] to toggle the shuffle. [true] to turn shuffle on and [false]
   /// to turn it off respectively.
-  ///
-  /// Returns the current player state by making another request.
-  /// See [playbackState([String market])];
-  Future<PlaybackState> shuffle(bool state, [String? deviceId]) async {
-    return _api
-        ._put('$_path/shuffle?' +
-            _buildQuery({'state': state, 'deviceId': deviceId}))
-        .then(playbackState);
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> shuffle(bool state,
+      {String? deviceId, bool retrievePlaybackState = true}) async {
+    await _api._put('$_path/shuffle?' +
+        _buildQuery({'state': state, 'deviceId': deviceId}));
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 
   /// Returns the current playback state, including progress, track
@@ -81,45 +81,73 @@ class PlayerEndpoint extends MeEndpointBase {
 
   /// Start a new context or resume current playback on the user's active device.
   /// [deviceId] is optional. If not provided, the user's currently active device
-  /// is the target. [options] is optional. If not provided, playback will start
+  /// is the target.
+  /// [options] is optional. If not provided, playback will start
   /// from the context's current track.
-  Future<Null> startOrResume(
-      {String? deviceId, StartOrResumeOptions? options}) async {
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> startOrResume(
+      {String? deviceId,
+      StartOrResumeOptions? options,
+      bool retrievePlaybackState = true}) async {
     var body = options?.toJson();
     var json = jsonEncode(body ?? '');
 
     await _api._put(
         '$_path/play?' + _buildQuery({'device_id': deviceId}), json);
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 
   /// Pause playback on the user's account.
   /// [deviceId] is optional. If not provided, the user's currently active device
   /// is the target.
-  Future<Null> pause([String? deviceId]) async {
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> pause(
+      {String? deviceId, bool retrievePlaybackState = true}) async {
     await _api._put('$_path/pause?' + _buildQuery({'device_id': deviceId}));
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 
   /// Skips to previous track in the user’s queue.
   /// [deviceId] is optional. If not provided, the user's currently active device
   /// is the target.
-  Future<Null> previous([String? deviceId]) async {
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> previous(
+      {String? deviceId, bool retrievePlaybackState = true}) async {
     await _api._post('$_path/previous?' + _buildQuery({'device_id': deviceId}));
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 
   /// Skips to next track in the user’s queue.
   /// [deviceId] is optional. If not provided, the user's currently active device
   /// is the target.
-  Future<Null> next([String? deviceId]) async {
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> next(
+      {String? deviceId, bool retrievePlaybackState = true}) async {
     await _api._post('$_path/next?' + _buildQuery({'device_id': deviceId}));
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 
   /// Seeks to the given position in the user’s currently playing track.
   /// [positionMs] is required. The position in milliseconds to seek to.
   /// [deviceId] is optional. If not provided, the user's currently active device
   /// is the target.
-  Future<Null> seek(int positionMs, [String? deviceId]) async {
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> seek(int positionMs,
+      {String? deviceId, bool retrievePlaybackState = true}) async {
+    assert(positionMs >= 0, 'positionMs must be greater or equal to 0');
     await _api._put('$_path/seek?' +
         _buildQuery({'position_ms': positionMs, 'device_id': deviceId}));
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 
   /// Set the repeat mode for the user’s playback.
@@ -127,12 +155,17 @@ class PlayerEndpoint extends MeEndpointBase {
   /// [RepeatState.track], [RepeatState.context].
   /// [deviceId] is optional. If not provided, the user's currently active device
   /// is the target.
-  Future<Null> repeat(RepeatState state, [String? deviceId]) async {
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> repeat(RepeatState state,
+      {String? deviceId, bool retrievePlaybackState = true}) async {
     await _api._put('$_path/repeat?' +
         _buildQuery({
           'state': state.toString().split('.').last,
           'device_id': deviceId
         }));
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 
   /// Set the volume for the user’s current playback device.
@@ -140,8 +173,15 @@ class PlayerEndpoint extends MeEndpointBase {
   /// 100 inclusive.
   /// [deviceId] is optional. If not provided, the user's currently active device
   /// is the target.
-  Future<Null> volume(int volumePercent, [String? deviceId]) async {
+  /// [retrievePlaybackState] is optional. If true, the current playback state
+  /// will be retrieved after setting the volume. Defaults to true.
+  Future<PlaybackState?> volume(int volumePercent,
+      {String? deviceId, bool retrievePlaybackState = true}) async {
+    assert(volumePercent >= 0 && volumePercent <= 100,
+        'Volume must be between 0 and 100');
     await _api._put('$_path/volume?' +
         _buildQuery({'volume_percent': volumePercent, 'device_id': deviceId}));
+
+    return retrievePlaybackState ? playbackState() : null;
   }
 }

--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -13,40 +13,41 @@ class PlayerEndpoint extends MeEndpointBase {
   ///
   /// Use [state] to toggle the shuffle. [true] to turn shuffle on and [false]
   /// to turn it off respectively.
-  /// 
+  ///
   /// Returns the current player state by making another request.
   /// See [playbackState([String market])];
-  Future<Player> shuffle(bool state, [String? deviceId]) async {
-    return _api._put('$_path/shuffle?' + _buildQuery({
-                    'state': state,
-                    'deviceId': deviceId})).then(playbackState);
+  Future<PlaybackState> shuffle(bool state, [String? deviceId]) async {
+    return _api
+        ._put('$_path/shuffle?' +
+            _buildQuery({'state': state, 'deviceId': deviceId}))
+        .then(playbackState);
   }
 
   /// Returns the current playback state, including progress, track
   /// and active device.
   @Deprecated('Use [playbackState] instead')
-  Future<Player> player([String? market]) async {
+  Future<PlaybackState> player([String? market]) async {
     return playbackState(market);
   }
 
   /// Returns the current playback state, including progress, track
   /// and active device.
-  Future<Player> playbackState([String? market]) async {
+  Future<PlaybackState> playbackState([String? market]) async {
     var jsonString =
         await _api._get('$_path?' + _buildQuery({'market': market}));
     final map = json.decode(jsonString);
-    return Player.fromJson(map);
+    return PlaybackState.fromJson(map);
   }
 
   /// Get the object currently being played on the user’s Spotify account.
-  Future<Player> currentlyPlaying() async {
+  Future<PlaybackState> currentlyPlaying() async {
     final jsonString = await _api._get('$_path/currently-playing');
 
     if (jsonString.isEmpty) {
-      return Player();
+      return PlaybackState();
     }
 
-    return Player.fromJson(json.decode(jsonString));
+    return PlaybackState.fromJson(json.decode(jsonString));
   }
 
   // Get the currently playing as well as the queued objects.
@@ -76,5 +77,71 @@ class PlayerEndpoint extends MeEndpointBase {
 
     final items = map['devices'] as Iterable<dynamic>;
     return items.map((item) => Device.fromJson(item));
+  }
+
+  /// Start a new context or resume current playback on the user's active device.
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target. [options] is optional. If not provided, playback will start
+  /// from the context's current track.
+  Future<Null> startOrResume(
+      {String? deviceId, StartOrResumeOptions? options}) async {
+    var body = options?.toJson();
+    var json = jsonEncode(body ?? '');
+
+    await _api._put(
+        '$_path/play?' + _buildQuery({'device_id': deviceId}), json);
+  }
+
+  /// Pause playback on the user's account.
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target.
+  Future<Null> pause([String? deviceId]) async {
+    await _api._put('$_path/pause?' + _buildQuery({'device_id': deviceId}));
+  }
+
+  /// Skips to previous track in the user’s queue.
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target.
+  Future<Null> previous([String? deviceId]) async {
+    await _api._post('$_path/previous?' + _buildQuery({'device_id': deviceId}));
+  }
+
+  /// Skips to next track in the user’s queue.
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target.
+  Future<Null> next([String? deviceId]) async {
+    await _api._post('$_path/next?' + _buildQuery({'device_id': deviceId}));
+  }
+
+  /// Seeks to the given position in the user’s currently playing track.
+  /// [positionMs] is required. The position in milliseconds to seek to.
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target.
+  Future<Null> seek(int positionMs, [String? deviceId]) async {
+    await _api._put('$_path/seek?' +
+        _buildQuery({'position_ms': positionMs, 'device_id': deviceId}));
+  }
+
+  /// Set the repeat mode for the user’s playback.
+  /// [state] is required. Options are: [RepeatState.off],
+  /// [RepeatState.track], [RepeatState.context].
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target.
+  Future<Null> repeat(RepeatState state, [String? deviceId]) async {
+    await _api._put('$_path/repeat?' +
+        _buildQuery({
+          'state': state.toString().split('.').last,
+          'device_id': deviceId
+        }));
+  }
+
+  /// Set the volume for the user’s current playback device.
+  /// [volumePercent] is required. The volume to set. Must be a value from 0 to
+  /// 100 inclusive.
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target.
+  Future<Null> volume(int volumePercent, [String? deviceId]) async {
+    await _api._put('$_path/volume?' +
+        _buildQuery({'volume_percent': volumePercent, 'device_id': deviceId}));
   }
 }

--- a/lib/src/models/_models.dart
+++ b/lib/src/models/_models.dart
@@ -1,5 +1,7 @@
 library spotify.models;
 
+import 'dart:convert';
+
 import 'package:json_annotation/json_annotation.dart';
 import 'package:spotify/spotify.dart';
 

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -211,6 +211,9 @@ PlaybackState _$PlaybackStateFromJson(Map<String, dynamic> json) =>
           : Track.fromJson(json['item'] as Map<String, dynamic>)
       ..currentlyPlayingType = $enumDecodeNullable(
           _$CurrentlyPlayingTypeEnumMap, json['currently_playing_type'])
+      ..actions = json['actions'] == null
+          ? null
+          : Actions.fromJson(json['actions'] as Map<String, dynamic>)
       ..isPlaying = json['is_playing'] as bool? ?? false
       ..isShuffling = json['shuffle_state'] as bool? ?? false
       ..repeatState =
@@ -238,6 +241,18 @@ PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) =>
       ..href = json['href'] as String?
       ..type = json['type'] as String?
       ..uri = json['uri'] as String?;
+
+Actions _$ActionsFromJson(Map<String, dynamic> json) => Actions()
+  ..interruptingPlayback = json['interrupting_playback'] as bool? ?? false
+  ..pausing = json['pausing'] as bool? ?? false
+  ..resuming = json['resuming'] as bool? ?? false
+  ..seeking = json['seeking'] as bool? ?? false
+  ..skippingNext = json['skipping_next'] as bool? ?? false
+  ..skippingPrev = json['skipping_prev'] as bool? ?? false
+  ..togglingRepeatContext = json['toggling_repeat_context'] as bool? ?? false
+  ..togglingRepeatTrack = json['toggling_repeat_track'] as bool? ?? false
+  ..togglingShuffle = json['toggling_shuffle'] as bool? ?? false
+  ..transferringPlayback = json['transferring_playback'] as bool? ?? false;
 
 Map<String, dynamic> _$StartOrResumeOptionsToJson(
         StartOrResumeOptions instance) =>

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -199,22 +199,23 @@ CursorPaging<T> _$CursorPagingFromJson<T>(Map<String, dynamic> json) =>
 Cursor _$CursorFromJson(Map<String, dynamic> json) =>
     Cursor()..after = json['after'] as String?;
 
-Player _$PlayerFromJson(Map<String, dynamic> json) => Player()
-  ..timestamp = json['timestamp'] as int?
-  ..context = json['context'] == null
-      ? null
-      : PlayerContext.fromJson(json['context'] as Map<String, dynamic>)
-  ..progress_ms = json['progress_ms'] as int?
-  ..item = json['item'] == null
-      ? null
-      : Track.fromJson(json['item'] as Map<String, dynamic>)
-  ..currentlyPlayingType = $enumDecodeNullable(
-      _$CurrentlyPlayingTypeEnumMap, json['currently_playing_type'])
-  ..isPlaying = json['is_playing'] as bool? ?? false
-  ..isShuffling = json['shuffle_state'] as bool? ?? false
-  ..repeatState =
-      $enumDecodeNullable(_$RepeatStateEnumMap, json['repeat_state']) ??
-          RepeatState.off;
+PlaybackState _$PlaybackStateFromJson(Map<String, dynamic> json) =>
+    PlaybackState()
+      ..timestamp = json['timestamp'] as int?
+      ..context = json['context'] == null
+          ? null
+          : PlayerContext.fromJson(json['context'] as Map<String, dynamic>)
+      ..progress_ms = json['progress_ms'] as int?
+      ..item = json['item'] == null
+          ? null
+          : Track.fromJson(json['item'] as Map<String, dynamic>)
+      ..currentlyPlayingType = $enumDecodeNullable(
+          _$CurrentlyPlayingTypeEnumMap, json['currently_playing_type'])
+      ..isPlaying = json['is_playing'] as bool? ?? false
+      ..isShuffling = json['shuffle_state'] as bool? ?? false
+      ..repeatState =
+          $enumDecodeNullable(_$RepeatStateEnumMap, json['repeat_state']) ??
+              RepeatState.off;
 
 const _$CurrentlyPlayingTypeEnumMap = {
   CurrentlyPlayingType.track: 'track',
@@ -237,6 +238,33 @@ PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) =>
       ..href = json['href'] as String?
       ..type = json['type'] as String?
       ..uri = json['uri'] as String?;
+
+Map<String, dynamic> _$StartOrResumeOptionsToJson(
+        StartOrResumeOptions instance) =>
+    <String, dynamic>{
+      'context_uri': instance.contextUri,
+      'uris': instance.uris,
+      'offset': StartOrResumeOptions._offsetToJson(instance.offset),
+      'position_ms': instance.positionMs,
+    };
+
+UriOffset _$UriOffsetFromJson(Map<String, dynamic> json) => UriOffset(
+      json['uri'] as String,
+    );
+
+Map<String, dynamic> _$UriOffsetToJson(UriOffset instance) => <String, dynamic>{
+      'uri': instance.uri,
+    };
+
+PositionOffset _$PositionOffsetFromJson(Map<String, dynamic> json) =>
+    PositionOffset(
+      json['position'] as int,
+    );
+
+Map<String, dynamic> _$PositionOffsetToJson(PositionOffset instance) =>
+    <String, dynamic>{
+      'position': instance.position,
+    };
 
 Playlist _$PlaylistFromJson(Map<String, dynamic> json) => Playlist()
   ..collaborative = json['collaborative'] as bool?

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -63,23 +63,20 @@ class PlayerContext extends Object {
 @JsonSerializable(createFactory: false)
 class StartOrResumeOptions extends Object {
   /// Optional. Spotify URI of the context to play. Valid contexts are albums,
-  /// artists & playlists. {context_uri:"spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"}
+  /// artists & playlists.
+  /// Example: "spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"
   @JsonKey(name: 'context_uri')
   String? contextUri;
 
   /// Optional. A JSON array of the Spotify track URIs to play. For example:
-  /// { "uris": [
+  /// Example: [
   ///     "spotify:track:4iV5W9uYEdYUVa79Axb7Rh",
   ///     "spotify:track:1301WleyT98MSxVHPZCA6M"
-  /// ]}
+  /// ]
   List<String>? uris;
 
   /// Optional. Indicates from where in the context playback should start.
   /// Only available when context_uri corresponds to an album or playlist object
-  /// "position" is zero based and can’t be negative.
-  /// Example: "offset": {"position": 5} "uri" is a string representing the uri
-  /// of the item to start at.
-  ///  Example: "offset": {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M"}
   @JsonKey(toJson: _offsetToJson)
   Offset? offset;
 
@@ -105,6 +102,8 @@ class StartOrResumeOptions extends Object {
 
 abstract class Offset {}
 
+/// "uri" is a string representing the uri of the item to start at.
+/// Example: "spotify:track:1301WleyT98MSxVHPZCA6M"
 @JsonSerializable()
 class UriOffset extends Offset {
   final String uri;
@@ -112,6 +111,7 @@ class UriOffset extends Offset {
   UriOffset(this.uri);
 }
 
+/// "position" is zero based and can’t be negative.
 @JsonSerializable()
 class PositionOffset extends Offset {
   final int position;

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -27,6 +27,10 @@ class PlaybackState extends Object {
   @JsonKey(name: 'currently_playing_type')
   CurrentlyPlayingType? currentlyPlayingType;
 
+  /// Allows to update the user interface based on which playback actions are
+  /// available within the current context.
+  Actions? actions;
+
   /// [true] if something is currently playing.
   @JsonKey(name: 'is_playing', defaultValue: false)
   bool? isPlaying;
@@ -58,6 +62,54 @@ class PlayerContext extends Object {
 
   /// The uri of the context.
   String? uri;
+}
+
+@JsonSerializable(createToJson: false)
+class Actions extends Object {
+  Actions();
+
+  factory Actions.fromJson(Map<String, dynamic> json) =>
+      _$ActionsFromJson(json);
+
+  /// Interrupting playback. Optional field.
+  @JsonKey(name: 'interrupting_playback', defaultValue: false)
+  bool? interruptingPlayback;
+
+  /// Pausing playback. Optional field.
+  @JsonKey(name: 'pausing', defaultValue: false)
+  bool? pausing;
+
+  /// Resuming playback. Optional field.
+  @JsonKey(name: 'resuming', defaultValue: false)
+  bool? resuming;
+
+  /// Seeking playback location. Optional field.
+  @JsonKey(name: 'seeking', defaultValue: false)
+  bool? seeking;
+
+  /// Skipping to the next context. Optional field.
+  @JsonKey(name: 'skipping_next', defaultValue: false)
+  bool? skippingNext;
+
+  /// Skipping to the previous context. Optional field.
+  @JsonKey(name: 'skipping_prev', defaultValue: false)
+  bool? skippingPrev;
+
+  /// Toggling repeat context flag. Optional field.
+  @JsonKey(name: 'toggling_repeat_context', defaultValue: false)
+  bool? togglingRepeatContext;
+
+  /// Toggling repeat track flag. Optional field.
+  @JsonKey(name: 'toggling_repeat_track', defaultValue: false)
+  bool? togglingRepeatTrack;
+
+  /// Toggling shuffle flag. Optional field.
+  @JsonKey(name: 'toggling_shuffle', defaultValue: false)
+  bool? togglingShuffle;
+
+  /// Transfering playback between devices. Optional field.
+  @JsonKey(name: 'transferring_playback', defaultValue: false)
+  bool? transferringPlayback;
 }
 
 @JsonSerializable(createFactory: false)

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -4,10 +4,11 @@
 part of spotify.models;
 
 @JsonSerializable(createToJson: false)
-class Player extends Object {
-  Player();
+class PlaybackState extends Object {
+  PlaybackState();
 
-  factory Player.fromJson(Map<String, dynamic> json) => _$PlayerFromJson(json);
+  factory PlaybackState.fromJson(Map<String, dynamic> json) =>
+      _$PlaybackStateFromJson(json);
 
   /// Unix Millisecond Timestamp when data was fetched
   int? timestamp;
@@ -57,6 +58,65 @@ class PlayerContext extends Object {
 
   /// The uri of the context.
   String? uri;
+}
+
+@JsonSerializable(createFactory: false)
+class StartOrResumeOptions extends Object {
+  /// Optional. Spotify URI of the context to play. Valid contexts are albums,
+  /// artists & playlists. {context_uri:"spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"}
+  @JsonKey(name: 'context_uri')
+  String? contextUri;
+
+  /// Optional. A JSON array of the Spotify track URIs to play. For example:
+  /// { "uris": [
+  ///     "spotify:track:4iV5W9uYEdYUVa79Axb7Rh",
+  ///     "spotify:track:1301WleyT98MSxVHPZCA6M"
+  /// ]}
+  List<String>? uris;
+
+  /// Optional. Indicates from where in the context playback should start.
+  /// Only available when context_uri corresponds to an album or playlist object
+  /// "position" is zero based and can’t be negative.
+  /// Example: "offset": {"position": 5} "uri" is a string representing the uri
+  /// of the item to start at.
+  ///  Example: "offset": {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M"}
+  @JsonKey(toJson: _offsetToJson)
+  Offset? offset;
+
+  /// Optional. The position in milliseconds to start playback.
+  @JsonKey(name: 'position_ms')
+  int? positionMs;
+
+  StartOrResumeOptions(
+      {this.contextUri, this.uris, this.offset, this.positionMs});
+
+  Map<String, dynamic> toJson() => _$StartOrResumeOptionsToJson(this);
+
+  static Map<String, dynamic> _offsetToJson(Offset? offset) {
+    if (offset is UriOffset) {
+      return {'uri': offset.uri};
+    } else if (offset is PositionOffset) {
+      return {'position': offset.position};
+    } else {
+      return {};
+    }
+  }
+}
+
+abstract class Offset {}
+
+@JsonSerializable()
+class UriOffset extends Offset {
+  final String uri;
+
+  UriOffset(this.uri);
+}
+
+@JsonSerializable()
+class PositionOffset extends Offset {
+  final int position;
+
+  PositionOffset(this.position);
 }
 
 enum RepeatState { off, context, track }

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -68,7 +68,7 @@ class StartOrResumeOptions extends Object {
   @JsonKey(name: 'context_uri')
   String? contextUri;
 
-  /// Optional. A JSON array of the Spotify track URIs to play. For example:
+  /// Optional. A JSON array of the Spotify track URIs to play.
   /// Example: [
   ///     "spotify:track:4iV5W9uYEdYUVa79Axb7Rh",
   ///     "spotify:track:1301WleyT98MSxVHPZCA6M"
@@ -116,7 +116,9 @@ class UriOffset extends Offset {
 class PositionOffset extends Offset {
   final int position;
 
-  PositionOffset(this.position);
+  PositionOffset(this.position) {
+    assert(position >= 0, 'Position must be greater than or equal to 0');
+  }
 }
 
 enum RepeatState { off, context, track }

--- a/test/data/v1/me/player.json
+++ b/test/data/v1/me/player.json
@@ -23,16 +23,18 @@
     "item": {
         "album": {
             "album_type": "album",
-            "artists": [{
-                "external_urls": {
-                    "spotify": "https://open.spotify.com/artist/2aaLAng2L2aWD2FClzwiep"
-                },
-                "href": "https://api.spotify.com/v1/artists/2aaLAng2L2aWD2FClzwiep",
-                "id": "2aaLAng2L2aWD2FClzwiep",
-                "name": "Dream Theater",
-                "type": "artist",
-                "uri": "spotify:artist:2aaLAng2L2aWD2FClzwiep"
-            }],
+            "artists": [
+                {
+                    "external_urls": {
+                        "spotify": "https://open.spotify.com/artist/2aaLAng2L2aWD2FClzwiep"
+                    },
+                    "href": "https://api.spotify.com/v1/artists/2aaLAng2L2aWD2FClzwiep",
+                    "id": "2aaLAng2L2aWD2FClzwiep",
+                    "name": "Dream Theater",
+                    "type": "artist",
+                    "uri": "spotify:artist:2aaLAng2L2aWD2FClzwiep"
+                }
+            ],
             "available_markets": [
                 "AD",
                 "AE",
@@ -132,7 +134,8 @@
             },
             "href": "https://api.spotify.com/v1/albums/2qMujQgkbogm4owxpt8aVP",
             "id": "2qMujQgkbogm4owxpt8aVP",
-            "images": [{
+            "images": [
+                {
                     "height": 640,
                     "url": "https://i.scdn.co/image/ab67616d0000b2730fbdbfc4dd5b2b93448c7104",
                     "width": 640
@@ -155,16 +158,18 @@
             "type": "album",
             "uri": "spotify:album:2qMujQgkbogm4owxpt8aVP"
         },
-        "artists": [{
-            "external_urls": {
-                "spotify": "https://open.spotify.com/artist/2aaLAng2L2aWD2FClzwiep"
-            },
-            "href": "https://api.spotify.com/v1/artists/2aaLAng2L2aWD2FClzwiep",
-            "id": "2aaLAng2L2aWD2FClzwiep",
-            "name": "Dream Theater",
-            "type": "artist",
-            "uri": "spotify:artist:2aaLAng2L2aWD2FClzwiep"
-        }],
+        "artists": [
+            {
+                "external_urls": {
+                    "spotify": "https://open.spotify.com/artist/2aaLAng2L2aWD2FClzwiep"
+                },
+                "href": "https://api.spotify.com/v1/artists/2aaLAng2L2aWD2FClzwiep",
+                "id": "2aaLAng2L2aWD2FClzwiep",
+                "name": "Dream Theater",
+                "type": "artist",
+                "uri": "spotify:artist:2aaLAng2L2aWD2FClzwiep"
+            }
+        ],
         "available_markets": [
             "AD",
             "AE",
@@ -280,10 +285,16 @@
     },
     "currently_playing_type": "track",
     "actions": {
-        "disallows": {
-            "resuming": true,
-            "skipping_prev": true
-        }
+        "interrupting_playback": false,
+        "pausing": true,
+        "resuming": false,
+        "seeking": false,
+        "skipping_next": false,
+        "skipping_prev": false,
+        "toggling_repeat_context": false,
+        "toggling_shuffle": false,
+        "toggling_repeat_track": false,
+        "transferring_playback": false
     },
     "is_playing": true
 }

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -298,6 +298,8 @@ Future main() async {
       expect(result.isPlaying, true);
       expect(result.currentlyPlayingType, CurrentlyPlayingType.track);
       expect(result.repeatState, RepeatState.off);
+      expect(result.actions?.resuming, false);
+      expect(result.actions?.pausing, true);
     });
   });
 


### PR DESCRIPTION
This PR adds these player related endpoints:

- start or resume playback
- pause playback
- previous track
- next track
- seek to position in currently playing track
- repeat playback
- volume control

@hayribakici in the `shuffle` endpoint you're making another call to `playbackState` and returning that response and I was wondering, if you think we should do this for these methods, too? 🤔 