### PR TITLE
Adds episode API

### DIFF
--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -25,6 +25,7 @@ part 'src/endpoints/browse.dart';
 part 'src/endpoints/categories.dart';
 part 'src/endpoints/endpoint_base.dart';
 part 'src/endpoints/endpoint_paging.dart';
+part 'src/endpoints/episodes.dart';
 part 'src/endpoints/me.dart';
 part 'src/endpoints/player.dart';
 part 'src/endpoints/playlists.dart';

--- a/lib/src/endpoints/episodes.dart
+++ b/lib/src/endpoints/episodes.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, hayribakici. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+part of spotify;
+
+class Episodes extends EndpointPaging {
+  @override
+  String get _path => 'v1/episodes';
+
+  Episodes(SpotifyApiBase api) : super(api);
+
+  Future<EpisodeFull> get(String id, [String? market]) async {
+    assert(id.isNotEmpty, 'No episode id was provided');
+    var jsonString =
+        await _api._get('$_path/$id?' + _buildQuery({'market': market}));
+    return EpisodeFull.fromJson(jsonDecode(jsonString));
+  }
+
+  Future<Iterable<EpisodeFull>> list(List<String> ids,
+      [String? market]) async {
+    assert(ids.isNotEmpty, 'No episode id\'s were provided');
+    var jsonString = await _api._get(
+        '$_path?' + _buildQuery({'ids': ids.join(','), 'market': market}));
+    var episodesJson = jsonDecode(jsonString)['episodes'] as Iterable<dynamic>;
+    return episodesJson.map((json) => EpisodeFull.fromJson(json));
+  }
+}

--- a/lib/src/endpoints/episodes.dart
+++ b/lib/src/endpoints/episodes.dart
@@ -3,7 +3,7 @@
 
 part of spotify;
 
-class Episodes extends EndpointPaging {
+class Episodes extends EndpointBase {
   @override
   String get _path => 'v1/episodes';
 

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -137,7 +137,12 @@ Category _$CategoryFromJson(Map<String, dynamic> json) => Category()
 
 Copyright _$CopyrightFromJson(Map<String, dynamic> json) => Copyright()
   ..text = json['text'] as String?
-  ..type = json['type'] as String?;
+  ..type = $enumDecodeNullable(_$CopyrightTypeEnumMap, json['type']);
+
+const _$CopyrightTypeEnumMap = {
+  CopyrightType.C: 'C',
+  CopyrightType.P: 'P',
+};
 
 Device _$DeviceFromJson(Map<String, dynamic> json) => Device()
   ..id = json['id'] as String?
@@ -346,7 +351,8 @@ Show _$ShowFromJson(Map<String, dynamic> json) => Show()
   ..name = json['name'] as String?
   ..publisher = json['publisher'] as String?
   ..type = json['type'] as String?
-  ..uri = json['uri'] as String?;
+  ..uri = json['uri'] as String?
+  ..totalEpisodes = json['total_episodes'] as int? ?? 0;
 
 Episode _$EpisodeFromJson(Map<String, dynamic> json) => Episode()
   ..audioPreviewUrl = json['audio_preview_url'] as String?
@@ -373,6 +379,35 @@ Episode _$EpisodeFromJson(Map<String, dynamic> json) => Episode()
   ..releaseDatePrecision = json['release_date_precision'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
+
+EpisodeFull _$EpisodeFullFromJson(Map<String, dynamic> json) => EpisodeFull()
+  ..audioPreviewUrl = json['audio_preview_url'] as String?
+  ..description = json['description'] as String?
+  ..durationMs = json['duration_ms'] as int?
+  ..explicit = json['explicit'] as bool?
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..href = json['href'] as String?
+  ..id = json['id'] as String?
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..isExternallyHosted = json['is_externally_hosted'] as bool?
+  ..isPlayable = json['is_playable'] as bool?
+  ..language = json['language'] as String?
+  ..languages =
+      (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..name = json['name'] as String?
+  ..releaseDate = json['release_date'] == null
+      ? null
+      : DateTime.parse(json['release_date'] as String)
+  ..releaseDatePrecision = json['release_date_precision'] as String?
+  ..type = json['type'] as String?
+  ..uri = json['uri'] as String?
+  ..show = json['show'] == null
+      ? null
+      : Show.fromJson(json['show'] as Map<String, dynamic>);
 
 Track _$TrackFromJson(Map<String, dynamic> json) => Track()
   ..album = json['album'] == null

--- a/lib/src/models/copyright.dart
+++ b/lib/src/models/copyright.dart
@@ -13,8 +13,13 @@ class Copyright extends Object {
   /// The copyright text for this album.
   String? text;
 
-  /// The type of copyright:
-  ///     C = the copyright
-  ///     P = the sound recording (performance) copyright.
-  String? type;
+  /// The type of copyright
+  CopyrightType? type;
+}
+
+enum CopyrightType {
+  /// C = the copyright
+  C,
+  /// P = the sound recording (performance) copyright.
+  P
 }

--- a/lib/src/models/episode.dart
+++ b/lib/src/models/episode.dart
@@ -75,3 +75,14 @@ class Episode extends Object {
   factory Episode.fromJson(Map<String, dynamic> json) =>
       _$EpisodeFromJson(json);
 }
+
+@JsonSerializable(createToJson: false)
+class EpisodeFull extends Episode {
+
+  EpisodeFull();
+
+  Show? show;
+
+  factory EpisodeFull.fromJson(Map<String, dynamic> json) =>
+      _$EpisodeFullFromJson(json);
+}

--- a/lib/src/models/show.dart
+++ b/lib/src/models/show.dart
@@ -59,5 +59,8 @@ class Show {
   /// The Spotify URI for the show.
   String? uri;
 
+  @JsonKey(name: 'total_episodes', defaultValue: 0)
+  int? totalEpisodes;
+
   factory Show.fromJson(Map<String, dynamic> json) => _$ShowFromJson(json);
 }

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -21,6 +21,8 @@ abstract class SpotifyApiBase {
   Tracks get tracks => _tracks;
   late Playlists _playlists;
   Playlists get playlists => _playlists;
+  late Episodes _episodes;
+  Episodes get episodes => _episodes;
   late RecommendationsEndpoint _recommendations;
   RecommendationsEndpoint get recommendations => _recommendations;
   late Users _users;
@@ -46,6 +48,7 @@ abstract class SpotifyApiBase {
     _albums = Albums(this);
     _browse = Browse(this);
     _tracks = Tracks(this);
+    _episodes = Episodes(this);
     _playlists = Playlists(this);
     _recommendations = RecommendationsEndpoint(this);
     _player = PlayerEndpoint(this);

--- a/test/data/v1/episodes/5Xt5DXGzch68nYYamXrNxZ.json
+++ b/test/data/v1/episodes/5Xt5DXGzch68nYYamXrNxZ.json
@@ -1,0 +1,75 @@
+{
+  "audio_preview_url": "https://p.scdn.co/mp3-preview/2f37da1d4221f40b9d1a98cd191f4d6f1646ad17",
+  "description": "A Spotify podcast sharing fresh insights on important topics of the moment—in a way only Spotify can. You’ll hear from experts in the music, podcast and tech industries as we discover and uncover stories about our work and the world around us.",
+  "html_description": "<p>A Spotify podcast sharing fresh insights on important topics of the moment—in a way only Spotify can. You’ll hear from experts in the music, podcast and tech industries as we discover and uncover stories about our work and the world around us.</p>\n",
+  "duration_ms": 1686230,
+  "explicit": true,
+  "external_urls": {
+    "spotify": "string"
+  },
+  "href": "https://api.spotify.com/v1/episodes/5Xt5DXGzch68nYYamXrNxZ",
+  "id": "5Xt5DXGzch68nYYamXrNxZ",
+  "images": [
+    {
+      "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+      "height": 300,
+      "width": 300
+    }
+  ],
+  "is_externally_hosted": true,
+  "is_playable": true,
+  "language": "en",
+  "languages": [
+    "fr",
+    "en"
+  ],
+  "name": "Starting Your Own Podcast: Tips, Tricks, and Advice From Anchor Creators",
+  "release_date": "1981-12-15",
+  "release_date_precision": "day",
+  "resume_point": {
+    "fully_played": true,
+    "resume_position_ms": 0
+  },
+  "type": "episode",
+  "uri": "spotify:episode:0zLhl3WsOCQHbe1BPTiHgr",
+  "restrictions": {
+    "reason": "string"
+  },
+  "show": {
+    "available_markets": [
+      "string"
+    ],
+    "copyrights": [
+      {
+        "text": "No rights",
+        "type": "C"
+      }
+    ],
+    "description": "hi",
+    "html_description": "string",
+    "explicit": true,
+    "external_urls": {
+      "spotify": "string"
+    },
+    "href": "string",
+    "id": "string",
+    "images": [
+      {
+        "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+        "height": 300,
+        "width": 300
+      }
+    ],
+    "is_externally_hosted": true,
+    "languages": [
+      "string"
+    ],
+    "media_type": "string",
+    "name": "The No-Show",
+    "publisher": "string",
+    "type": "show",
+    "uri": "string",
+    "total_episodes": 1
+  }
+
+}

--- a/test/data/v1/me/episodes.json
+++ b/test/data/v1/me/episodes.json
@@ -1,0 +1,87 @@
+{
+  "href": "https://api.spotify.com/v1/me/shows?offset=0&limit=20\n",
+  "limit": 20,
+  "next": "https://api.spotify.com/v1/me/shows?offset=1&limit=1",
+  "offset": 0,
+  "previous": "https://api.spotify.com/v1/me/shows?offset=1&limit=1",
+  "total": 4,
+  "items": [
+    {
+      "added_at": "2019-08-24T14:15:22Z",
+      "episode": {
+        "audio_preview_url": "https://p.scdn.co/mp3-preview/2f37da1d4221f40b9d1a98cd191f4d6f1646ad17",
+        "description": "A Spotify podcast sharing fresh insights on important topics of the moment—in a way only Spotify can. You’ll hear from experts in the music, podcast and tech industries as we discover and uncover stories about our work and the world around us.\n",
+        "html_description": "<p>A Spotify podcast sharing fresh insights on important topics of the moment—in a way only Spotify can. You’ll hear from experts in the music, podcast and tech industries as we discover and uncover stories about our work and the world around us.</p>\n",
+        "duration_ms": 1686230,
+        "explicit": true,
+        "external_urls": {
+          "spotify": "string"
+        },
+        "href": "https://api.spotify.com/v1/episodes/5Xt5DXGzch68nYYamXrNxZ",
+        "id": "5Xt5DXGzch68nYYamXrNxZ",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+            "height": 300,
+            "width": 300
+          }
+        ],
+        "is_externally_hosted": true,
+        "is_playable": true,
+        "language": "en",
+        "languages": [
+          "fr",
+          "en"
+        ],
+        "name": "Starting Your Own Podcast: Tips, Tricks, and Advice From Anchor Creators",
+        "release_date": "1981-12-15",
+        "release_date_precision": "day",
+        "resume_point": {
+          "fully_played": true,
+          "resume_position_ms": 0
+        },
+        "type": "episode",
+        "uri": "spotify:episode:0zLhl3WsOCQHbe1BPTiHgr",
+        "restrictions": {
+          "reason": "string"
+        },
+        "show": {
+          "available_markets": [
+            "string"
+          ],
+          "copyrights": [
+            {
+              "text": "string",
+              "type": "string"
+            }
+          ],
+          "description": "string",
+          "html_description": "string",
+          "explicit": true,
+          "external_urls": {
+            "spotify": "string"
+          },
+          "href": "string",
+          "id": "string",
+          "images": [
+            {
+              "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "is_externally_hosted": true,
+          "languages": [
+            "string"
+          ],
+          "media_type": "string",
+          "name": "string",
+          "publisher": "string",
+          "type": "show",
+          "uri": "string",
+          "total_episodes": 0
+        }
+      }
+    }
+  ]
+}

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -125,6 +125,7 @@ Future main() async {
       expect(show.type, 'show');
       expect(show.id, '4AlxqGkkrqe0mfIx3Mi7Xt');
       expect(show.name, 'Universo Flutter');
+      expect(show.totalEpisodes, 26);
     });
 
     test('list', () async {
@@ -174,7 +175,7 @@ Future main() async {
       expect(result.item!.name, 'As I Am');
     });
 
-    test('devices', () async {
+    test('Devices', () async {
       var result = await spotify.player.devices();
       expect(result.length, 1);
       expect(result.first.id, '5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e');
@@ -288,6 +289,32 @@ Future main() async {
       expect(list[albumIds[0]], isTrue);
       expect(list[albumIds[1]], isFalse);
       expect(list[albumIds[2]], isTrue);
+    });
+
+    group('Episodes', () {
+      test('getEpisode', () async {
+        var result = await spotify.episodes.get('5Xt5DXGzch68nYYamXrNxZ');
+
+        expect(result.durationMs, 1686230);
+        expect(result.explicit, true);
+        expect(result.audioPreviewUrl,
+            'https://p.scdn.co/mp3-preview/2f37da1d4221f40b9d1a98cd191f4d6f1646ad17');
+        expect(result.href,
+            'https://api.spotify.com/v1/episodes/5Xt5DXGzch68nYYamXrNxZ');
+        expect(result.name,
+            'Starting Your Own Podcast: Tips, Tricks, and Advice From Anchor Creators');
+        expect(result.releaseDate, DateTime(1981, 12, 15));
+        expect(result.type, 'episode');
+        expect(result.description,
+            'A Spotify podcast sharing fresh insights on important topics of the moment—in a way only Spotify can. You’ll hear from experts in the music, podcast and tech industries as we discover and uncover stories about our work and the world around us.');
+        expect(result.show == null, false);
+
+        var show = result.show;
+        expect(show?.copyrights?.first.type, CopyrightType.C);
+        expect(show?.isExternallyHosted, true);
+        expect(show?.name, 'The No-Show');
+        expect(show?.totalEpisodes, 1);
+      });
     });
   });
 


### PR DESCRIPTION
This PR adds the the episode api. Currently it consists of the the following endpoints:

* `getEpisode`
* `listEpisodes`

Furthermore a new class `EpisodeFull` has been created that contains the `show` as in the [response json](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-episode).