### PR TITLE
More Documentation

### DIFF
--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -34,7 +34,7 @@ part 'src/endpoints/search.dart';
 part 'src/endpoints/shows.dart';
 part 'src/endpoints/tracks.dart';
 part 'src/endpoints/users.dart';
-part 'src/spotify.dart';
+part 'src/spotify_api.dart';
 part 'src/spotify_base.dart';
 part 'src/spotify_credentials.dart';
 part 'src/spotify_exception.dart';

--- a/lib/src/endpoints/albums.dart
+++ b/lib/src/endpoints/albums.dart
@@ -3,12 +3,14 @@
 
 part of spotify;
 
+/// Endpoint for albums `v1/albums`
 class Albums extends EndpointPaging {
   @override
   String get _path => 'v1/albums';
 
   Albums(SpotifyApiBase api) : super(api);
 
+  /// Retrieves an album with its [albumId]
   Future<Album> get(String albumId) async {
     var jsonString = await _get('$_path/$albumId');
     var map = json.decode(jsonString);
@@ -16,6 +18,7 @@ class Albums extends EndpointPaging {
     return Album.fromJson(map);
   }
 
+  /// Returns album informations about a list of [albumIds]
   Future<Iterable<Album>> list(Iterable<String> albumIds) async {
     var jsonString = await _get('$_path?ids=${albumIds.join(',')}');
     var map = json.decode(jsonString);
@@ -24,6 +27,7 @@ class Albums extends EndpointPaging {
     return artistsMap.map((m) => Album.fromJson(m));
   }
 
+  /// Returns the tracks of a given [albumId]
   Pages<TrackSimple> getTracks(String albumId) {
     return _getPages(
         '$_path/$albumId/tracks', (json) => TrackSimple.fromJson(json));

--- a/lib/src/endpoints/artists.dart
+++ b/lib/src/endpoints/artists.dart
@@ -3,12 +3,14 @@
 
 part of spotify;
 
+/// Endpoint for artists `v1/artists`
 class Artists extends EndpointPaging {
   @override
   String get _path => 'v1/artists';
 
   Artists(SpotifyApiBase api) : super(api);
 
+  /// Retrieves an artist with its [artistId]
   Future<Artist> get(String artistId) async {
     var jsonString = await _api._get('$_path/$artistId');
     var map = json.decode(jsonString);
@@ -16,6 +18,7 @@ class Artists extends EndpointPaging {
     return Artist.fromJson(map);
   }
 
+  /// Returns the top tracks of an artist with its [artistId] inside a [countryCoude]
   Future<Iterable<Track>> getTopTracks(
       String artistId, String countryCode) async {
     var jsonString =
@@ -26,14 +29,11 @@ class Artists extends EndpointPaging {
     return topTracks.map((m) => Track.fromJson(m));
   }
 
-  Future<Iterable<Artist>> getRelatedArtists(String artistId) async {
-    var jsonString = await _api._get('$_path/$artistId/related-artists');
-    var map = json.decode(jsonString);
+  /// Returns related artists based on the artist with its [artistId]
+  @Deprecated('Use relatedArtists instead')
+  Future<Iterable<Artist>> getRelatedArtists(String artistId) async => relatedArtists(artistId);
 
-    var relatedArtists = map['artists'] as Iterable<dynamic>;
-    return relatedArtists.map((m) => Artist.fromJson(m));
-  }
-
+  /// Retrieves multiple artists with [artistIds]
   Future<Iterable<Artist>> list(Iterable<String> artistIds) async {
     var jsonString = await _api._get('$_path?ids=${artistIds.join(',')}');
     var map = json.decode(jsonString);
@@ -42,6 +42,7 @@ class Artists extends EndpointPaging {
     return artistsMap.map((m) => Artist.fromJson(m));
   }
 
+  /// Returns related artists based on the artist with its [artistId]
   Future<Iterable<Artist>> relatedArtists(String artistId) async {
     var jsonString = await _api._get('$_path/$artistId/related-artists');
     var map = json.decode(jsonString);

--- a/lib/src/endpoints/artists.dart
+++ b/lib/src/endpoints/artists.dart
@@ -18,7 +18,7 @@ class Artists extends EndpointPaging {
     return Artist.fromJson(map);
   }
 
-  /// Returns the top tracks of an artist with its [artistId] inside a [countryCoude]
+  /// Returns the top tracks of an artist with its [artistId] inside a [countryCode]
   Future<Iterable<Track>> getTopTracks(
       String artistId, String countryCode) async {
     var jsonString =

--- a/lib/src/endpoints/audio_features.dart
+++ b/lib/src/endpoints/audio_features.dart
@@ -3,12 +3,14 @@
 
 part of spotify;
 
+/// Endpoint of audio features `v1/audio-features`
 class AudioFeatures extends EndpointBase {
   @override
   String get _path => 'v1/audio-features';
 
   AudioFeatures(SpotifyApiBase api) : super(api);
 
+  /// Returns audio features of a track with [trackId]
   Future<AudioFeature> get(String trackId) async {
     var jsonString = await _api._get('$_path/$trackId');
     var map = json.decode(jsonString);
@@ -16,6 +18,7 @@ class AudioFeatures extends EndpointBase {
     return AudioFeature.fromJson(map);
   }
 
+  /// Retrieve multiple audio features of tracks with [trackIds]
   Future<Iterable<AudioFeature>> list(Iterable<String> trackIds) async {
     var jsonString = await _api._get('$_path?ids=${trackIds.join(',')}');
     var map = json.decode(jsonString);

--- a/lib/src/endpoints/browse.dart
+++ b/lib/src/endpoints/browse.dart
@@ -1,5 +1,6 @@
 part of spotify;
 
+/// Endpoint of browse `v1/browse`
 class Browse extends EndpointPaging {
   Browse(SpotifyApiBase api) : super(api);
 

--- a/lib/src/endpoints/categories.dart
+++ b/lib/src/endpoints/categories.dart
@@ -1,5 +1,6 @@
 part of spotify;
 
+/// Endpoint of browsing the categories `v1/browse/categories`
 class Categories extends Browse {
   
   @override

--- a/lib/src/endpoints/endpoint_base.dart
+++ b/lib/src/endpoints/endpoint_base.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// Base class of all endpoint classes
 abstract class EndpointBase {
   // ignore: unused_element
   String get _path;

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -3,7 +3,7 @@
 
 part of spotify;
 
-/// 
+/// Base class of all endpoints using pagination
 abstract class EndpointPaging extends EndpointBase {
   EndpointPaging(SpotifyApiBase api) : super(api);
 

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// 
 abstract class EndpointPaging extends EndpointBase {
   EndpointPaging(SpotifyApiBase api) : super(api);
 
@@ -283,7 +284,7 @@ class CursorPages<T> extends SinglePages<T, CursorPage<T>>
   }
 }
 
-/// Page that allows multiple types together
+/// Page that allows multiple types (artist, track, episode etc.) together
 class BundledPages extends _Pages with OffsetStrategy<List<Page<dynamic>>> {
   final Map<String, ParserFunction<dynamic>> _pageMappers;
 

--- a/lib/src/endpoints/episodes.dart
+++ b/lib/src/endpoints/episodes.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// Endpoint of episodes `v1/episodes`
 class Episodes extends EndpointBase {
   @override
   String get _path => 'v1/episodes';

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -3,14 +3,15 @@
 
 part of spotify;
 
-abstract class MeEndpointBase extends EndpointPaging {
+abstract class _MeEndpointBase extends EndpointPaging {
   @override
   String get _path => 'v1/me';
 
-  MeEndpointBase(SpotifyApiBase api) : super(api);
+  _MeEndpointBase(SpotifyApiBase api) : super(api);
 }
 
-class Me extends MeEndpointBase {
+/// Endpoint for authenticated users `v1/me/*`
+class Me extends _MeEndpointBase {
   late PlayerEndpoint _player;
 
   Me(SpotifyApiBase api, PlayerEndpoint player) : super(api) {

--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -3,7 +3,8 @@
 
 part of spotify;
 
-class PlayerEndpoint extends MeEndpointBase {
+/// Endpoint of the player
+class PlayerEndpoint extends _MeEndpointBase {
   @override
   String get _path => '${super._path}/player';
 

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// Endpoint of playlists
 class Playlists extends EndpointPaging {
   @override
   String get _path => 'v1/browse';
@@ -14,6 +15,7 @@ class Playlists extends EndpointPaging {
         jsonDecode(await _api._get('v1/playlists/$playlistId')));
   }
 
+  /// Returns the featuerd playlists
   Pages<PlaylistSimple> get featured => _getPages(
       '$_path/featured-playlists',
       (json) => PlaylistSimple.fromJson(json),
@@ -25,10 +27,13 @@ class Playlists extends EndpointPaging {
         'v1/me/playlists', (json) => PlaylistSimple.fromJson(json));
   }
 
+  /// Returns a playlist of a user with [userId]
   Pages<PlaylistSimple> getUsersPlaylists(String userId, [int limit = defaultLimit, int offset = 0]) {
     assert(userId.isNotEmpty, 'UserId cannot be empty');
     return _getPages('v1/users/$userId/playlists', (json) => PlaylistSimple.fromJson(json));
   }
+
+
   /// [playlistId] - the Spotify playlist ID
   Pages<Track> getTracksByPlaylistId(playlistId) {
     return _getPages('v1/playlists/$playlistId/tracks',

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// Endpoint of the search `v1/search`
 class Search extends EndpointPaging {
   @override
   String get _path => 'v1/search';
@@ -43,6 +44,7 @@ class Search extends EndpointPaging {
   }
 }
 
+/// Type for narrowing the search results
 class SearchType {
   final String _key;
 

--- a/lib/src/endpoints/shows.dart
+++ b/lib/src/endpoints/shows.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// Endpoint of shows `v1/shows`
 class Shows extends EndpointPaging {
   @override
   String get _path => 'v1/shows';

--- a/lib/src/endpoints/tracks.dart
+++ b/lib/src/endpoints/tracks.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// Endpoint of tracks `v1/tracks`
 class Tracks extends EndpointBase {
   late TracksMe _me;
 

--- a/lib/src/models/album.dart
+++ b/lib/src/models/album.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of an album
 @JsonSerializable(createToJson: false)
 class Album extends AlbumSimple {
   Album();

--- a/lib/src/models/artist.dart
+++ b/lib/src/models/artist.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of an artist
 @JsonSerializable(createToJson: false)
 class Artist extends Object implements ArtistSimple {
   Artist();
@@ -53,6 +54,7 @@ class Artist extends Object implements ArtistSimple {
   int? popularity;
 }
 
+/// Json representation of a simplified artist
 @JsonSerializable(createToJson: false)
 class ArtistSimple extends Object {
   ArtistSimple();

--- a/lib/src/models/audio_feature.dart
+++ b/lib/src/models/audio_feature.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of an audio feature
 @JsonSerializable(createToJson: false)
 class AudioFeature extends Object {
   AudioFeature();

--- a/lib/src/models/category.dart
+++ b/lib/src/models/category.dart
@@ -1,5 +1,6 @@
 part of spotify.models;
 
+/// Json representation of a category
 @JsonSerializable(createToJson: false)
 class Category extends Object {
   Category();

--- a/lib/src/models/copyright.dart
+++ b/lib/src/models/copyright.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of copyright
 @JsonSerializable(createToJson: false)
 class Copyright extends Object {
   Copyright();

--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of a device
 @JsonSerializable(createToJson: false)
 class Device extends Object {
   Device();
@@ -37,6 +38,7 @@ class Device extends Object {
   int? volumePercent;
 }
 
+/// API supported types
 enum DeviceType {
   Computer,
   Tablet,

--- a/lib/src/models/episode.dart
+++ b/lib/src/models/episode.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of an episode
 @JsonSerializable(createToJson: false)
 class Episode extends Object {
   Episode();
@@ -76,6 +77,7 @@ class Episode extends Object {
       _$EpisodeFromJson(json);
 }
 
+/// Json representation of an episode with information about its show
 @JsonSerializable(createToJson: false)
 class EpisodeFull extends Episode {
 

--- a/lib/src/models/error.dart
+++ b/lib/src/models/error.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of an API error
 @JsonSerializable(createToJson: false)
 class SpotifyError extends Object {
   SpotifyError();

--- a/lib/src/models/external_objects.dart
+++ b/lib/src/models/external_objects.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of an external url
 @JsonSerializable(createToJson: false)
 class ExternalUrls extends Object {
   ExternalUrls();
@@ -14,6 +15,7 @@ class ExternalUrls extends Object {
   String? spotify;
 }
 
+/// Json representation of an external id
 @JsonSerializable(createToJson: false)
 class ExternalIds extends Object {
   ExternalIds();

--- a/lib/src/models/followers.dart
+++ b/lib/src/models/followers.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of followers
 @JsonSerializable(createToJson: false)
 class Followers extends Object {
   Followers();

--- a/lib/src/models/image.dart
+++ b/lib/src/models/image.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of an image
 @JsonSerializable(createToJson: false)
 class Image extends Object {
   Image();

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -13,7 +13,7 @@ Iterable<dynamic> itemsNativeFromJson(List<dynamic> json) {
 List<Map> itemsNativeToJson(Iterable<dynamic>? items) =>
     (items == null) ? [] : List.from(items);
 
-/// A generic reprentation of a JSON page
+/// A generic representation of a JSON page
 class BasePaging<T> extends Object {
   BasePaging();
 

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -13,6 +13,7 @@ Iterable<dynamic> itemsNativeFromJson(List<dynamic> json) {
 List<Map> itemsNativeToJson(Iterable<dynamic>? items) =>
     (items == null) ? [] : List.from(items);
 
+/// A generic reprentation of a JSON page
 class BasePaging<T> extends Object {
   BasePaging();
 
@@ -35,6 +36,7 @@ class BasePaging<T> extends Object {
   String? next;
 }
 
+/// Json representation of a page with offset information
 @JsonSerializable(createToJson: false)
 class Paging<T> extends BasePaging<T> {
   Paging();
@@ -51,6 +53,7 @@ class Paging<T> extends BasePaging<T> {
   int total = 0;
 }
 
+/// Json representation of a page with cursor information
 @JsonSerializable(createToJson: false)
 class CursorPaging<T> extends BasePaging<T> {
   CursorPaging();
@@ -61,6 +64,7 @@ class CursorPaging<T> extends BasePaging<T> {
   Cursor? cursors;
 }
 
+/// Json representation of a cursor
 @JsonSerializable(createToJson: false)
 class Cursor extends Object {
   factory Cursor.fromJson(Map<String, dynamic> json) => _$CursorFromJson(json);

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -174,7 +174,7 @@ class PositionOffset extends Offset {
     assert(position >= 0, 'Position must be greater than or equal to 0');
   }
 }
-
+/// Representation of the current repeat state
 enum RepeatState { off, context, track }
 
 /// Representation of what is currently playing

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -45,7 +45,7 @@ class PlaybackState extends Object {
   RepeatState? repeatState;
 }
 
-/// Json representation of the context of the playbackState
+/// Json representation of the context of the playback state
 @JsonSerializable(createToJson: false)
 class PlayerContext extends Object {
   PlayerContext();

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -177,5 +177,5 @@ class PositionOffset extends Offset {
 
 enum RepeatState { off, context, track }
 
-/// Reprensation of what is currently playing
+/// Representation of what is currently playing
 enum CurrentlyPlayingType { track, episode, ad, unknown }

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of the playback state
 @JsonSerializable(createToJson: false)
 class PlaybackState extends Object {
   PlaybackState();
@@ -44,6 +45,7 @@ class PlaybackState extends Object {
   RepeatState? repeatState;
 }
 
+/// Json representation of the context of the playbackState
 @JsonSerializable(createToJson: false)
 class PlayerContext extends Object {
   PlayerContext();
@@ -175,4 +177,5 @@ class PositionOffset extends Offset {
 
 enum RepeatState { off, context, track }
 
+/// Reprensation of what is currently playing
 enum CurrentlyPlayingType { track, episode, ad, unknown }

--- a/lib/src/models/playlist.dart
+++ b/lib/src/models/playlist.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of a playlist
 @JsonSerializable(createToJson: false)
 class Playlist extends Object implements PlaylistSimple {
   Playlist();
@@ -81,6 +82,7 @@ class Playlist extends Object implements PlaylistSimple {
   String? uri;
 }
 
+/// Json representation of a simplified playlist
 @JsonSerializable(createToJson: false)
 class PlaylistSimple extends Object {
   PlaylistSimple();
@@ -142,6 +144,7 @@ class PlaylistSimple extends Object {
   String? uri;
 }
 
+/// Json representation of a featured playlist. Used as a wrapper object.
 @JsonSerializable(createToJson: false)
 class PlaylistsFeatured extends Object {
   PlaylistsFeatured();
@@ -153,6 +156,7 @@ class PlaylistsFeatured extends Object {
   String? message;
 }
 
+/// Json representation of a playlist with a single track
 @JsonSerializable(createToJson: false)
 class PlaylistTrack extends Object {
   PlaylistTrack();

--- a/lib/src/models/queue.dart
+++ b/lib/src/models/queue.dart
@@ -1,15 +1,16 @@
 part of spotify.models;
 
+/// Json representation of the playback queue
 @JsonSerializable(createToJson: false)
 class Queue extends Object {
   Queue();
 
   factory Queue.fromJson(Map<String, dynamic> json) => _$QueueFromJson(json);
 
-  // The currently playing track in the queue.
+  /// The currently playing track in the queue
   @JsonKey(name: 'currently_playing')
   Track? currentlyPlaying;
 
-  // All of the tracks that are added in the queue.
+  /// All of the tracks that are added in the queue
   List<Track>? queue;
 }

--- a/lib/src/models/recommendations.dart
+++ b/lib/src/models/recommendations.dart
@@ -16,7 +16,7 @@ class Recommendations extends Object {
   List<TrackSimple>? tracks;
 }
 
-/// Json representation of a the recommendation seed
+/// Json representation of the recommendation seed
 @JsonSerializable(createToJson: false)
 class RecommendationsSeed extends Object {
   RecommendationsSeed();

--- a/lib/src/models/recommendations.dart
+++ b/lib/src/models/recommendations.dart
@@ -1,5 +1,6 @@
 part of spotify.models;
 
+/// Json representation of the recommendations
 @JsonSerializable(createToJson: false)
 class Recommendations extends Object {
   Recommendations();
@@ -15,6 +16,7 @@ class Recommendations extends Object {
   List<TrackSimple>? tracks;
 }
 
+/// Json representation of a the recommendation seed
 @JsonSerializable(createToJson: false)
 class RecommendationsSeed extends Object {
   RecommendationsSeed();

--- a/lib/src/models/show.dart
+++ b/lib/src/models/show.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of a show
 @JsonSerializable(createToJson: false)
 class Show {
   Show();
@@ -59,6 +60,7 @@ class Show {
   /// The Spotify URI for the show.
   String? uri;
 
+  /// The number of total episodes in this show
   @JsonKey(name: 'total_episodes', defaultValue: 0)
   int? totalEpisodes;
 

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -118,7 +118,7 @@ class Track extends Object implements TrackSimple {
   String? uri;
 }
 
-/// Json representation of simplified track.
+/// Json representation of a simplified track.
 @JsonSerializable(createToJson: false)
 class TrackSimple extends Object {
   TrackSimple();

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of a track
 @JsonSerializable(createToJson: false)
 class Track extends Object implements TrackSimple {
   Track();
@@ -117,6 +118,7 @@ class Track extends Object implements TrackSimple {
   String? uri;
 }
 
+/// Json representation of simplified track.
 @JsonSerializable(createToJson: false)
 class TrackSimple extends Object {
   TrackSimple();

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -3,6 +3,7 @@
 
 part of spotify.models;
 
+/// Json representation of a user
 @JsonSerializable(createToJson: false)
 class User extends Object implements UserPublic {
   User();
@@ -71,6 +72,7 @@ class User extends Object implements UserPublic {
   String? uri;
 }
 
+/// Json representation of a publicly displayed user
 @JsonSerializable(createToJson: false)
 class UserPublic extends Object {
   UserPublic();
@@ -105,6 +107,7 @@ class UserPublic extends Object {
   String? uri;
 }
 
+/// Json representation of the playback history
 @JsonSerializable(createToJson: false)
 class PlayHistory extends Object {
   PlayHistory();

--- a/lib/src/spotify_api.dart
+++ b/lib/src/spotify_api.dart
@@ -3,6 +3,15 @@
 
 part of spotify;
 
+/// Accesspoint for the spotify api
+///
+/// Example usage:
+/// ```dart
+///   var credentials = SpotifyApiCredentials('my_id', 'my_secret');
+///   var spotify = SpotifyApi(credentials);
+///   var shows = spotify.shows.get('id);
+///   ...
+/// ```
 class SpotifyApi extends SpotifyApiBase {
   SpotifyApi(SpotifyApiCredentials credentials,
       {Function(SpotifyApiCredentials)? onCredentialsRefreshed})

--- a/lib/src/spotify_credentials.dart
+++ b/lib/src/spotify_credentials.dart
@@ -3,6 +3,7 @@
 
 part of spotify;
 
+/// Holds information about credentials to access the api.
 class SpotifyApiCredentials {
   /// The client identifier for this Spotify client.
   ///

--- a/lib/src/spotify_exception.dart
+++ b/lib/src/spotify_exception.dart
@@ -18,7 +18,7 @@ class SpotifyException implements Exception {
   String toString() => 'Error Code: $status\r\n$message';
 }
 
-/// Exception when the api-requsts has been exceeded
+/// Exception when the api requests have exceeded the rate limit
 class ApiRateException extends SpotifyException {
   final num retryAfter;
 

--- a/lib/src/spotify_exception.dart
+++ b/lib/src/spotify_exception.dart
@@ -18,6 +18,7 @@ class SpotifyException implements Exception {
   String toString() => 'Error Code: $status\r\n$message';
 }
 
+/// Exception when the api-requsts has been exceeded
 class ApiRateException extends SpotifyException {
   final num retryAfter;
 

--- a/test/spotify_mock.dart
+++ b/test/spotify_mock.dart
@@ -5,6 +5,7 @@ import 'package:spotify/spotify.dart';
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
 
+/// Mock classs for making requests
 class SpotifyApiMock extends SpotifyApiBase {
   SpotifyApiMock(SpotifyApiCredentials credentials)
       : super.fromClient(MockClient(credentials));

--- a/test/spotify_mock.dart
+++ b/test/spotify_mock.dart
@@ -5,7 +5,7 @@ import 'package:spotify/spotify.dart';
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
 
-/// Mock classs for making requests
+/// Mock class for making requests
 class SpotifyApiMock extends SpotifyApiBase {
   SpotifyApiMock(SpotifyApiCredentials credentials)
       : super.fromClient(MockClient(credentials));

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:spotify/src/spotify_mock.dart';
+import 'spotify_mock.dart';
 import 'package:test/test.dart';
 import 'package:spotify/spotify.dart';
 


### PR DESCRIPTION
This PR addresses #100 and adds more organization regarding this library.

Most of the changes contain small documentations of each endpoint and model classes.
In order to prevent confusion regarding multiple `spotify.dart` file names, the file with the `SpotifyApi` has been renamed to `spotify_api.dart`. 
Furthermore, the `spotify_mock` file has been moved to the `test` folder.