### PR TITLE
Making `dart doc` happy

### DIFF
--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -1,6 +1,14 @@
 // Copyright (c) 2017, rinukkusu. All rights reserved. Use of this source code
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
+/// A dart library for interfacing with the Spotify API. 
+/// 
+/// Example:
+/// ```dart
+///    final credentials = SpotifyApiCredentials(clientId, clientSecret);
+///    final spotify = SpotifyApi(credentials);
+///    final artist = await spotify.artists.get('0OdUWJ0sBjDrqHygGUXeCF');
+/// ```
 library spotify;
 
 import 'dart:async';

--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -2,13 +2,6 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 /// A dart library for interfacing with the Spotify API. 
-/// 
-/// Example:
-/// ```dart
-///    final credentials = SpotifyApiCredentials(clientId, clientSecret);
-///    final spotify = SpotifyApi(credentials);
-///    final artist = await spotify.artists.get('0OdUWJ0sBjDrqHygGUXeCF');
-/// ```
 library spotify;
 
 import 'dart:async';

--- a/lib/spotify_browser.dart
+++ b/lib/spotify_browser.dart
@@ -1,7 +1,0 @@
-// Copyright (c) 2017, rinukkusu. All rights reserved. Use of this source code
-// is governed by a BSD-style license that can be found in the LICENSE file.
-
-@Deprecated('Please import \'package:spotify/spotify.dart\' instead')
-library spotify;
-
-export 'spotify.dart';

--- a/lib/spotify_io.dart
+++ b/lib/spotify_io.dart
@@ -1,7 +1,0 @@
-// Copyright (c) 2017, rinukkusu. All rights reserved. Use of this source code
-// is governed by a BSD-style license that can be found in the LICENSE file.
-
-@Deprecated('Please import \'package:spotify/spotify.dart\' instead')
-library spotify;
-
-export 'spotify.dart';

--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -45,7 +45,7 @@ abstract class BasePage<T> {
   /// The requested data
   Iterable<T>? get items => _items;
 
-  /// [true] if this page is the last page. [false] otherwise.
+  /// `true` if this page is the last page. `false` otherwise.
   bool get isLast;
 
   /// Generic next for multiple purposes for internal use only.
@@ -61,7 +61,7 @@ abstract class BasePage<T> {
   Object? get container => _container;
 }
 
-/// A page that uses an [offset] to get to the next page.
+/// A page that uses an offset to get to the next page.
 class Page<T> extends BasePage<T> {
   Page(Paging<T> _paging, ParserFunction<T> pageItemParser,
       [Object? pageContainer])
@@ -79,11 +79,11 @@ class Page<T> extends BasePage<T> {
     return (paging.offset ?? 0) + paging.limit;
   }
 
-  /// Returns the [offset] for the next page.
+  /// Returns the offset for the next page.
   int get nextOffset => _next as int;
 }
 
-/// A page that uses a [cursor] to get to the next page
+/// A page that uses a cursor to get to the next page
 class CursorPage<T> extends BasePage<T> {
   CursorPage(CursorPaging<T> _paging, ParserFunction<T> pageItemParser,
       [Object? pageContainer])
@@ -92,7 +92,7 @@ class CursorPage<T> extends BasePage<T> {
   @override
   dynamic get _next => (_paging as CursorPaging<T>).cursors?.after ?? '';
 
-  /// The [cursor] pointing to the next page.
+  /// The cursor pointing to the next page.
   /// Is empty, when it's the last page.
   String get after => _next as String;
 

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -93,10 +93,10 @@ class Me extends _MeEndpointBase {
 
   /// Toggle Shuffle For User's Playback.
   ///
-  /// Use [state] to toggle the shuffle. [true] to turn shuffle on and [false]
+  /// Use [state] to toggle the shuffle. `true` to turn shuffle on and `false`
   /// to turn it off respectively.
   /// Returns the current player state by making another request.
-  /// See [player([String market])];
+  /// See [player(String market)];
   @Deprecated('Use [spotify.player.shuffle()]')
   Future<PlaybackState?> shuffle(bool state, [String? deviceId]) async =>
       _player.shuffle(state, deviceId: deviceId);

--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -12,7 +12,7 @@ class PlayerEndpoint extends _MeEndpointBase {
 
   /// Toggle Shuffle For User's Playback.
   ///
-  /// Use [state] to toggle the shuffle. [true] to turn shuffle on and [false]
+  /// Use [state] to toggle the shuffle. `true` to turn shuffle on and `false`
   /// to turn it off respectively.
   /// [retrievePlaybackState] is optional. If true, the current playback state
   /// will be retrieved after setting the volume. Defaults to true.

--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -10,30 +10,31 @@ class Device extends Object {
 
   factory Device.fromJson(Map<String, dynamic> json) => _$DeviceFromJson(json);
 
-  /// The device ID. This may be [null].
+  /// The device ID. This may be `null`.
   String? id;
 
   @JsonKey(name: 'is_active', defaultValue: false)
   bool? isActive;
 
   /// Whether controlling this device is restricted.
-  /// At present if this is [true] then no Web API commands will be
+  /// At present if this is `true` then no Web API commands will be
   /// accepted by this device.
   @JsonKey(name: 'is_private_session', defaultValue: false)
   bool? isPrivateSession;
 
   /// Whether controlling this device is restricted.
-  /// At present if this is [true] then no Web API commands will be accepted by this device.
+  /// At present if this is `true` then no Web API commands will be accepted by this device.
   @JsonKey(name: 'is_restricted', defaultValue: false)
   bool? isRestricted;
 
   /// The name of the device
   String? name;
 
-  /// [DeviceType], such as [Computer], [Smartphone] or [Speaker].
+  /// [DeviceType], such as [DeviceType.Computer], [DeviceType.Smartphone] or
+  /// [DeviceType.Speaker].
   DeviceType? type;
 
-  /// The current volume in percent. This may be null.
+  /// The current volume in percent. This may be `null`.
   @JsonKey(name: 'volume_percent')
   int? volumePercent;
 }

--- a/lib/src/models/episode.dart
+++ b/lib/src/models/episode.dart
@@ -10,7 +10,7 @@ class Episode extends Object {
 
   /// The episode length in milliseconds.
   /// A URL to a 30 second preview (MP3 format) of the episode.
-  /// [null] if not available.
+  /// `null` if not available.
   @JsonKey(name: 'audio_preview_url')
   String? audioPreviewUrl;
 
@@ -22,7 +22,7 @@ class Episode extends Object {
   int? durationMs;
 
   /// Whether or not the episode has explicit content
-  /// (true = yes it does; false = no it does not OR unknown).
+  /// (`true` = yes it does; `false` = no it does not OR unknown).
   bool? explicit;
 
   /// Known external URLs for this episode.

--- a/lib/src/models/paging.dart
+++ b/lib/src/models/paging.dart
@@ -32,7 +32,7 @@ class BasePaging<T> extends Object {
   /// default).
   int limit = 20;
 
-  /// URL to the next page of items. ([null] if none)
+  /// URL to the next page of items. (`null` if none)
   String? next;
 }
 

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -14,17 +14,17 @@ class PlaybackState extends Object {
   /// Unix Millisecond Timestamp when data was fetched
   int? timestamp;
 
-  /// A [PlayerContext] Object. Can be [null].
+  /// A [PlayerContext] Object. Can be `null`.
   PlayerContext? context;
 
-  /// Progress into the currently playing track. Can be [null].
+  /// Progress into the currently playing track. Can be `null`.
   int? progress_ms;
 
-  /// The currently playing track. Can be [null].
+  /// The currently playing track. Can be `null`.
   Track? item;
 
-  /// The object type of the currently playing item. Can be one of [track],
-  /// [episode], [ad] or [unknown].
+  /// The object type of the currently playing item. Can be one of [CurrentlyPlayingType.track],
+  /// [CurrentlyPlayingType.episode], [CurrentlyPlayingType.ad] or [CurrentlyPlayingType.unknown].
   @JsonKey(name: 'currently_playing_type')
   CurrentlyPlayingType? currentlyPlayingType;
 
@@ -32,15 +32,16 @@ class PlaybackState extends Object {
   /// available within the current context.
   Actions? actions;
 
-  /// [true] if something is currently playing.
+  /// `true` if something is currently playing.
   @JsonKey(name: 'is_playing', defaultValue: false)
   bool? isPlaying;
 
-  /// The shuffle state. [true] if shuffle is turned on, [false] if its turned off
+  /// The shuffle state. `true` if shuffle is turned on, `false` if its turned off
   @JsonKey(name: 'shuffle_state', defaultValue: false)
   bool? isShuffling;
 
-  /// The repeat state. Can be [off], [track] or [context]
+  /// The repeat state. Can be [RepeatState.off], [RepeatState.track] or 
+  /// [RepeatState.context]
   @JsonKey(name: 'repeat_state', defaultValue: RepeatState.off)
   RepeatState? repeatState;
 }
@@ -53,10 +54,10 @@ class PlayerContext extends Object {
   factory PlayerContext.fromJson(Map<String, dynamic> json) =>
       _$PlayerContextFromJson(json);
 
-  /// The external_urls of the context, or [null] if not available.
+  /// The external_urls of the context, or `null` if not available.
   ExternalUrls? external_urls;
 
-  /// The href of the context, or [null] if not available.
+  /// The href of the context, or `null` if not available.
   String? href;
 
   /// The object type of the item’s context. Can be one of album, artist or playlist.
@@ -123,10 +124,14 @@ class StartOrResumeOptions extends Object {
   String? contextUri;
 
   /// Optional. A JSON array of the Spotify track URIs to play.
-  /// Example: [
+  ///
+  /// Example: 
+  /// ```json
+  /// [
   ///     "spotify:track:4iV5W9uYEdYUVa79Axb7Rh",
   ///     "spotify:track:1301WleyT98MSxVHPZCA6M"
   /// ]
+  /// ```
   List<String>? uris;
 
   /// Optional. Indicates from where in the context playback should start.

--- a/lib/src/models/playlist.dart
+++ b/lib/src/models/playlist.dart
@@ -16,7 +16,7 @@ class Playlist extends Object implements PlaylistSimple {
   bool? collaborative;
 
   /// The playlist description. Only returned for modified, verified playlists,
-  /// otherwise [null].
+  /// otherwise `null`.
   @override
   String? description;
 
@@ -53,8 +53,8 @@ class Playlist extends Object implements PlaylistSimple {
   @override
   User? owner;
 
-  /// The playlist's public/private status: [true] the playlist is public,
-  /// [false] the playlist is private, null the playlist status is not relevant.
+  /// The playlist's public/private status: `true` the playlist is public,
+  /// `false` the playlist is private, null the playlist status is not relevant.
   /// For more about public/private status, see Working with Playlists.
   @override
   bool? public;
@@ -94,7 +94,7 @@ class PlaylistSimple extends Object {
   bool? collaborative;
 
   /// The playlist description. Only returned for modified, verified playlists,
-  /// otherwise [null].
+  /// otherwise `null`.
   String? description;
 
   /// Known external URLs for this playlist.
@@ -121,8 +121,8 @@ class PlaylistSimple extends Object {
   /// The user who owns the playlist
   User? owner;
 
-  /// The playlist's public/private status: [true] the playlist is public,
-  /// [false] the playlist is private, null the playlist status is not relevant.
+  /// The playlist's public/private status: `true` the playlist is public,
+  /// `false` the playlist is private, null the playlist status is not relevant.
   /// For more about public/private status, see Working with Playlists.
   bool? public;
 
@@ -165,12 +165,12 @@ class PlaylistTrack extends Object {
       _$PlaylistTrackFromJson(json);
 
   /// The date and time the track was added.
-  /// Note that some very old playlists may return [null] in this field.
+  /// Note that some very old playlists may return `null` in this field.
   @JsonKey(name: 'added_at')
   DateTime? addedAt;
 
   /// The Spotify user who added the track.
-  /// Note that some very old playlists may return [null] in this field.
+  /// Note that some very old playlists may return `null` in this field.
   @JsonKey(name: 'added_by')
   UserPublic? addedBy;
 

--- a/lib/src/models/recommendations.dart
+++ b/lib/src/models/recommendations.dart
@@ -8,7 +8,7 @@ class Recommendations extends Object {
   factory Recommendations.fromJson(Map<String, dynamic> json) =>
       _$RecommendationsFromJson(json);
 
-  /// A List of [RecommendationSeed] objects.
+  /// A List of [RecommendationsSeed] objects.
   List<RecommendationsSeed>? seeds;
 
   /// A List of [TrackSimple] objects ordered according to the parameters

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -26,7 +26,7 @@ class Track extends Object implements TrackSimple {
   List<String>? availableMarkets;
 
   /// The disc number
-  /// (usually [1] unless the album consists of more than one disc)
+  /// (usually `1` unless the album consists of more than one disc)
   @JsonKey(name: 'disc_number')
   @override
   int? discNumber;
@@ -42,7 +42,7 @@ class Track extends Object implements TrackSimple {
   Duration? get duration => Duration(milliseconds: durationMs ?? 0);
 
   /// Whether or not the track has explicit lyrics
-  /// ([true] = yes it does; [false] = no it does not OR unknown).
+  /// (`true` = yes it does; `false` = no it does not OR unknown).
   @override
   bool? explicit;
 
@@ -97,7 +97,7 @@ class Track extends Object implements TrackSimple {
   /// by a few days: the value is not updated in real time.
   int? popularity;
 
-  /// A URL to a 30 second preview (MP3 format) of the track. [null] if not
+  /// A URL to a 30 second preview (MP3 format) of the track. `null` if not
   /// available.
   @JsonKey(name: 'preview_url')
   @override
@@ -136,7 +136,7 @@ class TrackSimple extends Object {
   List<String>? availableMarkets;
 
   /// The disc number
-  /// (usually [1] unless the album consists of more than one disc)
+  /// (usually `1` unless the album consists of more than one disc)
   @JsonKey(name: 'disc_number')
   int? discNumber;
 
@@ -149,7 +149,7 @@ class TrackSimple extends Object {
   Duration? get duration => Duration(milliseconds: durationMs ?? 0);
 
   /// Whether or not the track has explicit lyrics
-  /// ([true] = yes it does; [false] = no it does not OR unknown).
+  /// (`true` = yes it does; `false` = no it does not OR unknown).
   bool? explicit;
 
   /// Known external URLs for this track.
@@ -177,7 +177,7 @@ class TrackSimple extends Object {
   /// The name of the track.
   String? name;
 
-  /// A URL to a 30 second preview (MP3 format) of the track. [null] if not
+  /// A URL to a 30 second preview (MP3 format) of the track. `null` if not
   /// available.
   @JsonKey(name: 'preview_url')
   String? previewUrl;


### PR DESCRIPTION
Adds library documentation and removes all warnings in order to make `dart doc` happy.

It also removes the deprecated files `spotify_io.dart` and `spotify_browser.dart` as they were the issue why `dart doc` throws errors. 