### PR TITLE
Update playlist items

### DIFF
--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -43,6 +43,8 @@ void main() async {
   // await _listEpisodes(spotify);
   // await _savedEpisodes(spotify);
   // await _saveAndRemoveEpisode(spotify);
+  print(
+      'WARNING! The following methods create multiple playlists on your account');
   await _clearPlaylist(spotify);
   await _reorderItemsInPlaylist(spotify);
   await _replaceItemsInPlaylist(spotify);
@@ -247,40 +249,57 @@ Future<Playlist> _createPrivatePlaylist(SpotifyApi spotify) async {
   return playlist;
 }
 
-Future<void> _clearPlaylist(SpotifyApi spotify) async {
-  var playlist = await _createPrivatePlaylist(spotify);
+Future<void> _removePrivatePlaylist(
+    SpotifyApi spotify, String playlistId) async {
+  print('Removing playlist $playlistId');
+  await spotify.playlists.unfollowPlaylist(playlistId);
+}
 
+Future<void> _clearPlaylist(SpotifyApi spotify) async {
+  print('Clearing Playlist');
+  var playlist = await _createPrivatePlaylist(spotify);
   var tracks = await _getPlaylistTracks(spotify, playlist.id ?? '');
   print('Tracks before: ${tracks.map((e) => e.name)}');
+
   await spotify.playlists.clear(playlist.id ?? '');
 
   tracks = await _getPlaylistTracks(spotify, playlist.id ?? '');
-  print('Tracks after: $tracks}');
+  print('Tracks after: ${tracks.map((e) => e.name)}');
+
+  await _removePrivatePlaylist(spotify, playlist.id ?? '');
 }
 
 Future<void> _reorderItemsInPlaylist(SpotifyApi spotify) async {
+  print('Reordering Playlist');
   var playlist = await _createPrivatePlaylist(spotify);
   var playlistId = playlist.id ?? '';
   var tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks before: $tracks}');
+  print('Tracks before: ${tracks.map((e) => e.name)}');
+
   // reorders the first element to the end of the playlist
-  await spotify.playlists.reorder(playlistId, 0, tracks.length);
+  await spotify.playlists
+      .reorder(playlistId, rangeStart: 0, insertBefore: tracks.length);
 
   tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks after: $tracks}');
+  print('Tracks after: ${tracks.map((e) => e.name)}');
+
+  await _removePrivatePlaylist(spotify, playlist.id ?? '');
 }
 
 Future<void> _replaceItemsInPlaylist(SpotifyApi spotify) async {
+  print('Replacing Playlist');
   var playlist = await _createPrivatePlaylist(spotify);
   var playlistId = playlist.id ?? '';
   var tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks before: $tracks}');
+  print('Tracks before: ${tracks.map((e) => e.name)}');
 
   // replaces the whole playlist with only the first item
-  await spotify.playlists.replace(playlistId, [tracks.first.id ?? '']);
+  await spotify.playlists.replace(playlistId, [tracks.first.uri ?? '']);
 
   tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks after: $tracks}');
+  print('Tracks after: ${tracks.map((e) => e.name)}');
+
+  await _removePrivatePlaylist(spotify, playlist.id ?? '');
 }
 
 Future<Iterable<Track>> _getPlaylistTracks(

--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -26,25 +26,23 @@ void main() async {
   if (spotify == null) {
     exit(0);
   }
-  // await _user(spotify);
-  // await _currentlyPlaying(spotify);
-  // await _devices(spotify);
-  // await _followingArtists(spotify);
-  // await _shuffle(true, spotify);
-  // await _shuffle(false, spotify);
-  // await _playlists(spotify);
-  // await _savedTracks(spotify);
-  // await _recentlyPlayed(spotify);
-  // await _getShow(spotify);
-  // await _listShows(spotify);
-  // await _savedShows(spotify);
-  // await _saveAndRemoveShow(spotify);
-  // await _getEpisode(spotify);
-  // await _listEpisodes(spotify);
-  // await _savedEpisodes(spotify);
-  // await _saveAndRemoveEpisode(spotify);
-  print(
-      'WARNING! The following methods create multiple playlists on your account');
+  await _user(spotify);
+  await _currentlyPlaying(spotify);
+  await _devices(spotify);
+  await _followingArtists(spotify);
+  await _shuffle(true, spotify);
+  await _shuffle(false, spotify);
+  await _playlists(spotify);
+  await _savedTracks(spotify);
+  await _recentlyPlayed(spotify);
+  await _getShow(spotify);
+  await _listShows(spotify);
+  await _savedShows(spotify);
+  await _saveAndRemoveShow(spotify);
+  await _getEpisode(spotify);
+  await _listEpisodes(spotify);
+  await _savedEpisodes(spotify);
+  await _saveAndRemoveEpisode(spotify);
   await _clearPlaylist(spotify);
   await _reorderItemsInPlaylist(spotify);
   await _replaceItemsInPlaylist(spotify);

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -187,7 +187,7 @@ class Playlists extends EndpointPaging {
       [String? snapshotId]) async {
     var body = jsonEncode({
       'uris': uris.join(','),
-      'snapshot_id': snapshotId,
+      // 'snapshot_id': snapshotId,
     });
     return _reorderOrReplace(playlistId, body);
   }
@@ -212,6 +212,7 @@ class Playlists extends EndpointPaging {
       [int rangeLength = 1, String? snapshotId]) async {
     assert(rangeStart >= 0, 'rangeStart out of bounds');
     var body = jsonEncode({
+      'rande_start': rangeStart,
       'insert_before': insertBefore,
       'range_length': rangeLength,
       'snapshot_id': snapshotId,

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -146,7 +146,7 @@ class Playlists extends EndpointPaging {
 
   /// Removes a track with [trackUri] in the playlist with [playlistId]
   ///
-  /// [trackUris] - the Spotify track uris
+  /// [trackUri] - the Spotify track uri
   /// (i.e each list item in the format of "spotify:track:4iV5W9uYEdYUVa79Axb7Rh")
   Future<void> removeTrack(String trackUri, String playlistId,
       [List<int>? positions]) async {


### PR DESCRIPTION
This PR implements the `v1/playlists/$playlistId/tracks` endpoint, which allows reordering, replacing and clearing playlist items. 

This PR also implements a "fake" remove playlist method (see comments in code).