### PR TITLE
Authorization scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ final redirectUri = 'https://example.com/auth';
 // See https://developer.spotify.com/documentation/general/guides/scopes/
 // for a complete list of these Spotify authorization permissions. If no
 // scopes are specified, only public Spotify information will be available.
-final scopes = ['user-read-email', 'user-library-read'];
+final scopes = [AuthorizationScope.user.readEmail, AuthorizationScope.library.read];
 
 final authUri = grant.getAuthorizationUrl(
   Uri.parse(redirectUri),

--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -7,15 +7,15 @@ import 'dart:io';
 
 import 'package:spotify/spotify.dart';
 
-const _scopes = [
-  'user-read-playback-state',
-  'user-follow-read',
-  'playlist-modify-private',
-  'playlist-modify-public',
-  'user-modify-playback-state',
-  'user-library-read',
-  'user-read-recently-played',
-  'user-library-modify'
+final _scopes = [
+  AuthorizationScope.playlist.modifyPrivate,
+  AuthorizationScope.playlist.modifyPublic,
+  AuthorizationScope.library.read,
+  AuthorizationScope.library.modify,
+  AuthorizationScope.connect.readPlaybackState,
+  AuthorizationScope.connect.modifyPlaybackState,
+  AuthorizationScope.listen.readRecentlyPlayed,
+  AuthorizationScope.follow.read
 ];
 
 void main() async {

--- a/lib/spotify.dart
+++ b/lib/spotify.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2017, rinukkusu. All rights reserved. Use of this source code
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
-/// A dart library for interfacing with the Spotify API. 
+/// A dart library for interfacing with the Spotify API.
 library spotify;
 
 import 'dart:async';
@@ -40,3 +40,4 @@ part 'src/spotify_base.dart';
 part 'src/spotify_credentials.dart';
 part 'src/spotify_exception.dart';
 part 'src/utils.dart';
+part 'src/authorization_scope.dart';

--- a/lib/src/authorization_scope.dart
+++ b/lib/src/authorization_scope.dart
@@ -1,0 +1,262 @@
+// Copyright (c) 2023, hayribakici. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+part of spotify;
+
+/// Class holding all available authorization scopes.
+/// See [Spotify scopes documentation](https://developer.spotify.com/documentation/web-api/concepts/scopes)
+class AuthorizationScope {
+  const AuthorizationScope();
+
+  /// Scope regarding users
+  static const UserAuthorizationScope user = UserAuthorizationScope();
+
+  /// Scope regarding playback
+  static PlaylistAuthorizationScope playlist = PlaylistAuthorizationScope();
+
+  /// Scope regarding images (e.g. playlist images)
+  static ImagesAuthorizationScope images = ImagesAuthorizationScope();
+
+  /// Scope regarding Spotify Connect
+  static ConnectAuthorizationScope connect = ConnectAuthorizationScope();
+
+  /// Scope regarding the user's library
+  static LibraryAuthorizationScope library = LibraryAuthorizationScope();
+
+  /// Scope regarding the user's listening history
+  static ListeningHistoryAuthorizationScope listen =
+      ListeningHistoryAuthorizationScope();
+
+  /// Scope regarding following artists or users
+  static FollowAuthorizationScope follow = FollowAuthorizationScope();
+
+  static final all = List.unmodifiable([
+    ...user.all,
+    ...playlist.all,
+    ...images.all,
+    ...connect.all,
+    ...library.all,
+    ...listen.all,
+    ...follow.all
+  ]);
+}
+
+abstract class _Scope {
+  const _Scope();
+
+  /// Contains all properties of this class
+  List<String> get all;
+}
+
+class FollowAuthorizationScope extends _Scope {
+  const FollowAuthorizationScope();
+
+  /// Read access to the list of artists and other users that the user follows.
+  ///
+  /// Endpoints that require the `user-follow-read` scope:
+  /// * [Me.isFollowing]
+  /// * [Me.following]
+  String get read => 'user-follow-read';
+
+  /// Write/delete access to the list of artists and other users that the user follows.
+  ///
+  /// Endpoints that require the `user-follow-modify` scope:
+  /// * [Me.follow]
+  /// * [Me.unfollow]
+  String get modify => 'user-follow-modify';
+
+  @override
+  List<String> get all => List.unmodifiable([read, modify]);
+}
+
+class ListeningHistoryAuthorizationScope extends _Scope {
+  const ListeningHistoryAuthorizationScope();
+
+  /// Read access to a user’s playback position in a content.
+  ///
+  /// Endpoints that require the `user-read-playback-position` scope:
+  /// * [Episodes.get]
+  /// * [Episodes.list]
+  /// * [Shows.get]
+  /// * [Shows.list]
+  /// * [Shows.episodes]
+  String get readPlaybackPosition => 'user-read-playback-position';
+
+  /// Read access to a user's top artists and tracks.
+  ///
+  /// Endpoints that require the `user-top-read` scope:
+  /// * [Me.topTracks]
+  /// * [Me.topArtists]
+  String get readTop => 'user-top-read';
+
+  /// Read access to a user’s recently played tracks.
+  ///
+  /// Endpoints that require the `user-read-recently-played` scope:
+  /// * [PlayerEndpoint.currentlyPlaying]
+  String get readRecentlyPlayed => 'user-read-recently-played';
+
+  @override
+  List<String> get all =>
+      List.unmodifiable([readPlaybackPosition, readTop, readRecentlyPlayed]);
+}
+
+class ConnectAuthorizationScope extends _Scope {
+  const ConnectAuthorizationScope();
+
+  /// Read access to a user’s player state.
+  ///
+  /// Endpoints that require the `user-read-playback-state` scope:
+  /// * [PlayerEndpoint.devices]
+  /// * [PlayerEndpoint.currentlyPlaying]
+  /// * [PlayerEndpoint.playbackState]
+  String get readPlaybackState => 'user-read-playback-state';
+
+  /// Write access to a user’s playback state.
+  ///
+  /// Endpoints that require the `user-modify-playback-state` scope:
+  /// * [PlayerEndpoint.pause]
+  /// * [PlayerEndpoint.previous]
+  /// * [PlayerEndpoint.next]
+  /// * [PlayerEndpoint.seek]
+  /// * [PlayerEndpoint.volume]
+  /// * [PlayerEndpoint.shuffle]
+  /// * [PlayerEndpoint.repeat]
+  /// * [PlayerEndpoint.startOrResume]
+  /// * [PlayerEndpoint.addToQueue]
+  String get modifyPlaybackState => 'user-modify-playback-state';
+
+  /// Read access to a user’s currently playing content.
+  ///
+  /// Endpoints that require the `user-read-currently-playing` scope:
+  /// * [PlayerEndpoint.currentlyPlaying]
+  /// * [PlayerEndpoint.queue]
+  String get readCurrentlyPlaying => 'user-read-currently-playing';
+
+  @override
+  List<String> get all => List.unmodifiable(
+      [readCurrentlyPlaying, readPlaybackState, modifyPlaybackState]);
+}
+
+class LibraryAuthorizationScope extends _Scope {
+  /// Read access to a user's library.
+  ///
+  /// Endpoints that require the `user-library-read` scope:
+  /// * [Me.savedEpisodes]
+  /// * [Me.containsSavedEpisodes]
+  /// * [Me.savedAlbums]
+  /// * [Me.containsSavedAlbums]
+  /// * [TracksMe.contains]
+  /// * [TracksMe.containsOne]
+  /// * [TracksMe.saved]
+  String get read => 'user-library-read';
+
+  /// Write/delete access to a user's "Your Music" library.
+  ///
+  /// Endpoints that require the `user-library-modify` scope:
+  /// * [Me.removeAlbums]
+  /// * [Me.removeEpisodes]
+  /// * [Me.saveEpisodes]
+  /// * [Me.saveAlbums]
+  /// * [TracksMe.saveOne]
+  /// * [TracksMe.save]
+  /// * [TracksMe.remove]
+  /// * [TracksMe.removeOne]
+  String get modify => 'user-library-modify';
+
+  @override
+  List<String> get all => List.unmodifiable([read, modify]);
+}
+
+class UserAuthorizationScope extends _Scope {
+  const UserAuthorizationScope() : super();
+
+  /// Read access to user’s subscription details (type of user account).
+  ///
+  /// Endpoints that require the `user-read-profile` scope:
+  /// * [Search.get]
+  /// * [Me.get]
+  String get readFollow => 'user-read-profile';
+
+  /// Read access to user’s email address.
+  ///
+  /// Endpoints that require the `user-read-email` scope:
+  /// * [Me.get]
+  String get readEmail => 'user-read-email';
+
+  /// Contains all properties of [AuthorizationScope.user]
+  @override
+  List<String> get all => List.unmodifiable([readFollow, readEmail]);
+}
+
+class PlaylistAuthorizationScope extends _Scope {
+  const PlaylistAuthorizationScope();
+
+  /// Read access to user's private playlists.
+  ///
+  /// Endpoints that require the `playlist-read-private` scope:
+  /// * [Playlists.followedBy]
+  /// * [Playlists.me]
+  /// * [Users.playlist]
+  String get readPrivate => 'playlist-read-private';
+
+  /// Write access to a user's private playlists.
+  ///
+  /// Endpoints that require the `playlist-modify-private` scope:
+  /// * [Playlists.followPlaylist]
+  /// * [Playlists.unfollowPlaylist]
+  /// * [Playlists.addTrack]
+  /// * [Playlists.addTracks]
+  /// * [Playlists.createPlaylist]
+  /// * [Playlists.updatePlaylist]
+  /// * [Playlists.removePlaylist]
+  /// * [Playlists.createPlaylist]
+  /// * [Playlists.removeTrack]
+  /// * [Playlists.removeTracks]
+  /// * [Playlists.replace]
+  /// * [Playlists.reorder]
+  /// * [Playlists.updatePlaylistImage]
+  String get modifyPrivate => 'playlist-modify-private';
+
+  /// Include collaborative playlists when requesting a user's playlists.
+  ///
+  /// Endpoints that require the `playlist-read-collaborative` scope:
+  /// * [Playlists.me]
+  /// * [Users.playlist]
+  String get readCollaborative => 'playlist-read-collaborative';
+
+  /// Write access to a user's public playlists.
+  ///
+  /// Endpoints that require the `playlist-modify-public` scope:
+  /// * [Playlists.followPlaylist]
+  /// * [Playlists.unfollowPlaylist]
+  /// * [Playlists.addTrack]
+  /// * [Playlists.addTracks]
+  /// * [Playlists.createPlaylist]
+  /// * [Playlists.updatePlaylist]
+  /// * [Playlists.removePlaylist]
+  /// * [Playlists.createPlaylist]
+  /// * [Playlists.removeTrack]
+  /// * [Playlists.removeTracks]
+  /// * [Playlists.replace]
+  /// * [Playlists.reorder]
+  /// * [Playlists.updatePlaylistImage]
+  String get modifyPublic => 'playlist-modify-public';
+
+  /// Contains all properties of [AuthorizationScope.playlist]
+  @override
+  List<String> get all => List.unmodifiable(
+      [readPrivate, readCollaborative, modifyPrivate, modifyPublic]);
+}
+
+class ImagesAuthorizationScope extends _Scope {
+  const ImagesAuthorizationScope();
+
+  /// Write access to user-provided images.
+  ///
+  /// Endpoints that require the `ugc-image-upload` scope:
+  /// * [Playlists.updatePlaylistImage]
+  String get imageUpload => 'ugc-image-upload';
+
+  @override
+  List<String> get all => [imageUpload];
+}

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -31,7 +31,7 @@ class Me extends _MeEndpointBase {
     // since 'artists' is the container, there is no
     // containerParse necessary. Adding json to make the
     // CursorPages-Object happy.
-    return _getCursorPages('$_path/following?type=${type.key}',
+    return _getCursorPages('$_path/following?type=${type._key}',
         (json) => Artist.fromJson(json), 'artists', (json) => json);
   }
 
@@ -40,7 +40,7 @@ class Me extends _MeEndpointBase {
   Future<List<bool>> isFollowing(FollowingType type, List<String> ids) async {
     assert(ids.isNotEmpty, 'No user/artist id was provided');
     final jsonString = await _api._get(
-        '$_path/following/contains?type=${type.key}&ids=${ids.join(",")}');
+        '$_path/following/contains?type=${type._key}&ids=${ids.join(",")}');
     final list = List.castFrom<dynamic, bool>(json.decode(jsonString));
     return list;
   }
@@ -50,7 +50,7 @@ class Me extends _MeEndpointBase {
   /// [ids] - user/artist
   Future<void> follow(FollowingType type, List<String> ids) async {
     assert(ids.isNotEmpty, 'No user/artist id was provided');
-    await _api._put("$_path/following?type=${type.key}&ids=${ids.join(",")}");
+    await _api._put("$_path/following?type=${type._key}&ids=${ids.join(",")}");
   }
 
   /// Unfollow already following users/artists\
@@ -59,7 +59,7 @@ class Me extends _MeEndpointBase {
   Future<void> unfollow(FollowingType type, List<String> ids) async {
     assert(ids.isNotEmpty, 'No user/artist id was provided');
     await _api
-        ._delete("$_path/following?type=${type.key}&ids=${ids.join(",")}");
+        ._delete("$_path/following?type=${type._key}&ids=${ids.join(",")}");
   }
 
   /// Get the object currently being played on the user’s Spotify account.
@@ -222,7 +222,7 @@ class Me extends _MeEndpointBase {
   /// Removes episodes for the current user. Requires the `user-library-modify`
   /// scope.
   /// [ids] - the ids of the episodes
-  Future<void> removeEpisode(List<String> ids) async {
+  Future<void> removeEpisodes(List<String> ids) async {
     assert(ids.isNotEmpty, 'No episode ids were provided for removing');
     await _api
         ._delete('$_path/episodes?' + _buildQuery({'ids': ids.join(',')}));

--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -207,8 +207,8 @@ class Me extends _MeEndpointBase {
   /// Returns the current user's saved episodes. Requires the `user-library-read`
   /// scope.
   Pages<EpisodeFull> savedEpisodes() {
-    return _getPages('$_path/episodes', 
-       (json) => EpisodeFull.fromJson(json['episode']));
+    return _getPages(
+        '$_path/episodes', (json) => EpisodeFull.fromJson(json['episode']));
   }
 
   /// Saves episodes for the current user. Requires the `user-library-modify`
@@ -240,12 +240,8 @@ class Me extends _MeEndpointBase {
   }
 }
 
-class FollowingType {
-  final String _key;
-
-  const FollowingType(this._key);
-
-  String get key => _key;
+class FollowingType extends ExtendedEnum {
+  const FollowingType(String key) : super(key);
 
   static const artist = FollowingType('artist');
   static const user = FollowingType('user');

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -45,11 +45,8 @@ class Search extends EndpointPaging {
 }
 
 /// Type for narrowing the search results
-class SearchType {
-  final String _key;
-
-  const SearchType(this._key);
-  String get key => _key;
+class SearchType extends ExtendedEnum {
+  const SearchType(String key) : super(key);
 
   static const album = SearchType('album');
   static const artist = SearchType('artist');

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -24,7 +24,7 @@ class Search extends EndpointPaging {
     Iterable<SearchType> types = SearchType.all,
     String market = '',
   }) {
-    var type = types.map((type) => type.key).join(',');
+    var type = types.map((type) => type._key).join(',');
 
     var queryMap = {'q': searchQuery, 'type': type};
     if (market.isNotEmpty) {

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -233,32 +233,6 @@ abstract class SpotifyApiBase {
         error,
       );
     }
-    AuthorizationScope.user.readFollow;
     return responseBody;
   }
-}
-
-class AuthorizationScope extends ExtendedEnum {
-  const AuthorizationScope(String key) : super(key);
-
-  static _UserAuthorizationScope user = _UserAuthorizationScope();
-
-  static const playlistModifyPrivate =
-      AuthorizationScope('playlist-modify-private');
-  static const playlistModifyPublic =
-      AuthorizationScope('playlist-modify-public');
-}
-
-class _UserAuthorizationScope {
-  _UserAuthorizationScope();
-
-  AuthorizationScope readFollow = AuthorizationScope('user-follow-read');
-  static const readPlaybackState =
-      AuthorizationScope('user-read-playback-state');
-  static const modifyPlaybackState =
-      AuthorizationScope('user-modify-playback-state');
-  static const readLibrary = AuthorizationScope('user-library-read');
-  static const modifyLibrary = AuthorizationScope('user-library-modify');
-  static const readRecentlyPlayed =
-      AuthorizationScope('user-read-recently-played');
 }

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -233,6 +233,32 @@ abstract class SpotifyApiBase {
         error,
       );
     }
+    AuthorizationScope.user.readFollow;
     return responseBody;
   }
+}
+
+class AuthorizationScope extends ExtendedEnum {
+  const AuthorizationScope(String key) : super(key);
+
+  static _UserAuthorizationScope user = _UserAuthorizationScope();
+
+  static const playlistModifyPrivate =
+      AuthorizationScope('playlist-modify-private');
+  static const playlistModifyPublic =
+      AuthorizationScope('playlist-modify-public');
+}
+
+class _UserAuthorizationScope {
+  _UserAuthorizationScope();
+
+  AuthorizationScope readFollow = AuthorizationScope('user-follow-read');
+  static const readPlaybackState =
+      AuthorizationScope('user-read-playback-state');
+  static const modifyPlaybackState =
+      AuthorizationScope('user-modify-playback-state');
+  static const readLibrary = AuthorizationScope('user-library-read');
+  static const modifyLibrary = AuthorizationScope('user-library-modify');
+  static const readRecentlyPlayed =
+      AuthorizationScope('user-read-recently-played');
 }

--- a/lib/src/spotify_credentials.dart
+++ b/lib/src/spotify_credentials.dart
@@ -32,7 +32,8 @@ class SpotifyApiCredentials {
 
   /// The specific permissions being requested from Spotify.
   ///
-  /// See https://developer.spotify.com/documentation/general/guides/scopes/
+  /// Use [AuthorizationScope] or
+  /// see https://developer.spotify.com/documentation/web-api/concepts/scopes
   /// for a full list of available scopes.
   List<String>? scopes;
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -14,3 +14,10 @@ Iterable<List<T>> batches<T>(Iterable<T> source, int size) sync* {
   }
   if (accumulator != null) yield accumulator;
 }
+
+class ExtendedEnum {
+  final String _key;
+
+  const ExtendedEnum(this._key);
+  String get key => _key;
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -19,5 +19,8 @@ class ExtendedEnum {
   final String _key;
 
   const ExtendedEnum(this._key);
-  String get key => _key;
+  // String get key => _key;
+
+  @override
+  String toString() => _key;
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -19,7 +19,6 @@ class ExtendedEnum {
   final String _key;
 
   const ExtendedEnum(this._key);
-  // String get key => _key;
 
   @override
   String toString() => _key;

--- a/test/spotify_mock.dart
+++ b/test/spotify_mock.dart
@@ -46,16 +46,7 @@ class MockClient implements oauth2.Client {
     var regex = RegExp(regexString);
     var urlString = url.toString();
     var partialPath = regex.firstMatch(urlString)!.group(1);
-    var file;
-    if (url.hasQuery &&
-        (url.queryParameters.containsKey('offset') ||
-            url.queryParameters.containsKey('after'))) {
-      var next = url.queryParameters['offset'] ?? url.queryParameters['after'];
-      file = File('test/data/${partialPath}_$next.json');
-    } else {
-      file = File('test/data/$partialPath.json');
-    }
-
+    var file = File('test/data/$partialPath.json');
     return file.readAsStringSync();
   }
 


### PR DESCRIPTION
This PR provides constants for the authorization scopes. With this, choosing the correct scope will be less error prone as it might happen that the user of this library makes spelling mistakes.

It also adds some refactoring with classes that contain a `key` property. I looked into it a little closer and the public `key` property should never be used outside of this library. Therefore it was removed.

I'm not 100% sure of this approach, dividing the scopes into different classes as they also could be fit into the `AuthorizationScope` class. What do you think?