### PR TITLE
Replaces `ExtendedEnum` with dart's enhanced enum concept

### DIFF
--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -263,26 +263,28 @@ class Me extends _MeEndpointBase {
   }
 }
 
-class FollowingType extends ExtendedEnum {
-  const FollowingType(String key) : super(key);
+enum FollowingType {
+  artist(key: 'artist'),
+  user(key: 'user');
 
-  static const artist = FollowingType('artist');
-  static const user = FollowingType('user');
+  const FollowingType({required String key}) : _key = key;
+
+  final String _key;
 }
 
-class TimeRange {
-  final String _key;
-
-  const TimeRange(this._key);
-
+enum TimeRange {
   /// Consists of several years of data and including all new data as it becomes available
-  static const longTerm = TimeRange('long_term');
+  longTerm(key: 'long_term'),
 
   /// Consists of approximately last 6 months
-  static const mediumTerm = TimeRange('medium_term');
+  mediumTerm(key: 'medium_term'),
 
   /// Consists of approximately last 4 weeks
-  static const shortTerm = TimeRange('short_term');
+  shortTerm(key: 'short_term');
+
+  const TimeRange({required String key}) : _key = key;
+
+  final String _key;
 }
 
 enum _TopItemsType { artists, tracks }

--- a/lib/src/endpoints/search.dart
+++ b/lib/src/endpoints/search.dart
@@ -21,7 +21,7 @@ class Search extends EndpointPaging {
   /// content that is playable in that market is returned.
   BundledPages get(
     String searchQuery, {
-    Iterable<SearchType> types = SearchType.all,
+    Iterable<SearchType> types = SearchType.values,
     Market? market,
   }) {
     var type = types.map((type) => type._key).join(',');
@@ -44,21 +44,15 @@ class Search extends EndpointPaging {
 }
 
 /// Type for narrowing the search results
-class SearchType extends ExtendedEnum {
-  const SearchType(String key) : super(key);
+enum SearchType {
+  album(key: 'album'),
+  artist(key: 'artist'),
+  playlist(key: 'playlist'),
+  track(key: 'track'),
+  show(key: 'show'),
+  episode(key: 'episode');
 
-  static const album = SearchType('album');
-  static const artist = SearchType('artist');
-  static const playlist = SearchType('playlist');
-  static const track = SearchType('track');
-  static const show = SearchType('show');
-  static const episode = SearchType('episode');
-  static const all = [
-    SearchType.album,
-    SearchType.artist,
-    SearchType.playlist,
-    SearchType.track,
-    SearchType.show,
-    SearchType.episode,
-  ];
+  const SearchType({required String key}) : _key = key;
+
+  final String _key;
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -14,12 +14,3 @@ Iterable<List<T>> batches<T>(Iterable<T> source, int size) sync* {
   }
   if (accumulator != null) yield accumulator;
 }
-
-class ExtendedEnum {
-  final String _key;
-
-  const ExtendedEnum(this._key);
-
-  @override
-  String toString() => _key;
-}


### PR DESCRIPTION
This PR replaces the `ExtendedEnum` class with dart's [enhanced enum](https://dart.dev/language/enum#declaring-enhanced-enums) concept resulting in less class overhead.