### PR TITLE
Handling of unknown `DeviceType`s

### DIFF
--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -485,7 +485,8 @@ Device _$DeviceFromJson(Map<String, dynamic> json) => Device()
   ..isPrivateSession = json['is_private_session'] as bool? ?? false
   ..isRestricted = json['is_restricted'] as bool? ?? false
   ..name = json['name'] as String?
-  ..type = $enumDecodeNullable(_$DeviceTypeEnumMap, json['type'])
+  ..type = $enumDecodeNullable(_$DeviceTypeEnumMap, json['type'],
+      unknownValue: DeviceType.Unknown)
   ..volumePercent = json['volume_percent'] as int?;
 
 const _$DeviceTypeEnumMap = {

--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -32,6 +32,8 @@ class Device extends Object {
 
   /// [DeviceType], such as [DeviceType.Computer], [DeviceType.Smartphone] or
   /// [DeviceType.Speaker].
+  ///
+  /// Sets to [DeviceType.Unknown] if the type is not supported.
   @JsonKey(unknownEnumValue: DeviceType.Unknown)
   DeviceType? type;
 

--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -32,6 +32,7 @@ class Device extends Object {
 
   /// [DeviceType], such as [DeviceType.Computer], [DeviceType.Smartphone] or
   /// [DeviceType.Speaker].
+  @JsonKey(unknownEnumValue: DeviceType.Unknown)
   DeviceType? type;
 
   /// The current volume in percent. This may be `null`.

--- a/test/data/v1/me/player/devices.json
+++ b/test/data/v1/me/player/devices.json
@@ -8,6 +8,15 @@
             "name": "My fridge",
             "type": "Computer",
             "volume_percent": 100
+        },
+        {
+            "id": "5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
+            "is_active": true,
+            "is_private_session": true,
+            "is_restricted": true,
+            "name": "SamsungGalaxy S3",
+            "type": "SmartWatch",
+            "volume_percent": 100
         }
     ]
 }

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -268,7 +268,7 @@ Future main() async {
 
     test('Devices', () async {
       var result = await spotify.player.devices();
-      expect(result.length, 1);
+      expect(result.length, 2);
       expect(result.first.id, '5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e');
       expect(result.first.isActive, true);
       expect(result.first.isRestricted, true);
@@ -276,6 +276,10 @@ Future main() async {
       expect(result.first.name, 'My fridge');
       expect(result.first.type, DeviceType.Computer);
       expect(result.first.volumePercent, 100);
+
+      // the second entry does not have a valid [DeviceType], 
+      // and should have `Unknown` instead.
+      expect(result.last.type, DeviceType.Unknown);
     });
 
     test('recentlyPlayed', () async {


### PR DESCRIPTION
This PR fixes #177 . 
Since the list of supported `DeviceType` values could not be found in the API documentation (e.g. `SmartWatch`), the library sets unknown enum values as `DeviceType.Unknown`. 