### PR TITLE
Restrict playlist return items to `tracks`

### DIFF
--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -35,7 +35,7 @@ class Playlists extends EndpointPaging {
         'v1/users/$userId/playlists', (json) => PlaylistSimple.fromJson(json));
   }
 
-  /// [playlistId] - the Spotify playlist ID
+  /// Returns `track`s from a given spotify [playlistId]
   Pages<Track> getTracksByPlaylistId(playlistId) {
     // restricting the return items to `track`
     final query = _buildQuery({'additional_types': 'track'});

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -37,7 +37,9 @@ class Playlists extends EndpointPaging {
 
   /// [playlistId] - the Spotify playlist ID
   Pages<Track> getTracksByPlaylistId(playlistId) {
-    return _getPages('v1/playlists/$playlistId/tracks',
+    // restricting the return items to `track`
+    final query = _buildQuery({'additional_types': 'track'});
+    return _getPages('v1/playlists/$playlistId/tracks$query',
         (json) => Track.fromJson(json['track']));
   }
 


### PR DESCRIPTION
This PR fixes #179. As pointed out by @addreeh that playlist items also contain `episodes`. For a quick fix, this PR restricts the return types to `tracks`. A seperate issue to support both `episode`s and `track`s is documented in #181.