### PR TITLE
Adds missing query start character

### DIFF
--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -39,7 +39,7 @@ class Playlists extends EndpointPaging {
   Pages<Track> getTracksByPlaylistId(playlistId) {
     // restricting the return items to `track`
     final query = _buildQuery({'additional_types': 'track'});
-    return _getPages('v1/playlists/$playlistId/tracks$query',
+    return _getPages('v1/playlists/$playlistId/tracks?$query',
         (json) => Track.fromJson(json['track']));
   }
 


### PR DESCRIPTION
Oopsiedaisy, forgot a `?` for the query in #182 .