### PR TITLE
Refactor `playOrResume`

### DIFF
--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -112,7 +112,8 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// will be retrieved. Default's to `true`.
   ///
   /// Note: Before starting a new playback context check the [playbackState]
-  /// if necessary before [resume]ing.
+  /// if necessary before [resume]ing, otherwise you overwrite the current
+  /// context.
   Future<PlaybackState?> startWithTracks(List<String> trackUris,
       {String? deviceId,
       int positionMs = 0,
@@ -134,7 +135,8 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// will be retrieved. Default's to `true`.
   ///
   /// Note: Before starting a new playback context check the [playbackState]
-  /// if necessary before [resume]ing.
+  /// if necessary before [resume]ing, otherwise you overwrite the current
+  /// context. 
   Future<PlaybackState?> startWithContext(String contextUri,
       {String? deviceId,
       Offset? offset,

--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -89,7 +89,8 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// from the context's current track.
   /// [retrievePlaybackState] is optional. If true, the current playback state
   /// will be retrieved. Defaults to true.
-  @Deprecated("Use `startWithTracks` or `startWithContext` instead")
+  @Deprecated(
+      "Use `startWithTracks()` or `startWithContext()` to start a new context and resume() instead")
   Future<PlaybackState?> startOrResume(
       {String? deviceId,
       StartOrResumeOptions? options,
@@ -103,17 +104,17 @@ class PlayerEndpoint extends _MeEndpointBase {
     return retrievePlaybackState ? playbackState() : null;
   }
 
-  /// Start a new playback context with given [trackUris] or resume current playback on the
-  /// user's active device.
-  /// [deviceId] is optional. If not provided, the user's currently active device
-  /// is the target.
-  /// [trackUris] is optional. If not provided, playback will start
-  /// from the context's current track.
+  /// Start a new playback context with given [trackUris] and with given optional
+  /// [deviceId]. If not provided, the user's currently active device
+  /// is the target. Playback can also start at [positionMs], which is set to `0`
+  /// by default.
   /// [retrievePlaybackState] is optional. If `true`, the current [PlaybackState]
   /// will be retrieved. Default's to `true`.
-  Future<PlaybackState?> startWithTracks(
+  ///
+  /// Note: Before starting a new playback context check the [playbackState]
+  /// if necessary before [resume]ing.
+  Future<PlaybackState?> startWithTracks(List<String> trackUris,
       {String? deviceId,
-      List<String> trackUris = const [],
       int positionMs = 0,
       bool retrievePlaybackState = true}) async {
     assert(trackUris.isNotEmpty, 'Cannot start playback with empty track uris');
@@ -127,18 +128,19 @@ class PlayerEndpoint extends _MeEndpointBase {
   }
 
   /// Start a new playback context (album, playlist) with given a [contextUri].
-  /// [deviceId] is optional. If not provided, the user's currently active device
-  /// is the target.
-  /// [contextUri] is optional. If not provided, playback will start
-  /// from the context's current track.
+  /// and given optional [deviceId]. If not provided, the user's currently active
+  /// device is the target. Set [Offset] to start playback at a specific point.
   /// [retrievePlaybackState] is optional. If `true`, the current [PlaybackState]
   /// will be retrieved. Default's to `true`.
-  Future<PlaybackState?> startWithContext(
+  ///
+  /// Note: Before starting a new playback context check the [playbackState]
+  /// if necessary before [resume]ing.
+  Future<PlaybackState?> startWithContext(String contextUri,
       {String? deviceId,
-      String? contextUri,
       Offset? offset,
       bool retrievePlaybackState = true}) async {
-    assert(contextUri?.isNotEmpty ?? false, 'Cannot start playback with empty context uri');
+    assert(
+        contextUri.isNotEmpty, 'Cannot start playback with empty context uri');
     var options = StartOrResumeOptions(contextUri: contextUri, offset: offset);
     return startOrResume(
         deviceId: deviceId,

--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -18,8 +18,7 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// will be retrieved after setting the volume. Defaults to true.
   Future<PlaybackState?> shuffle(bool state,
       {String? deviceId, bool retrievePlaybackState = true}) async {
-    await _api._put('$_path/shuffle?' +
-        _buildQuery({'state': state, 'deviceId': deviceId}));
+    await _api._put('$_path/shuffle?${_buildQuery({'state': state, 'deviceId': deviceId})}');
 
     return retrievePlaybackState ? playbackState() : null;
   }
@@ -34,8 +33,8 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// Returns the current playback state, including progress, track
   /// and active device.
   Future<PlaybackState> playbackState([Market? market]) async {
-    var jsonString = await _api
-        ._get('$_path?' + _buildQuery({'market': market?.name}));
+    var jsonString =
+        await _api._get('$_path?${_buildQuery({'market': market?.name})}');
     final map = json.decode(jsonString);
     return PlaybackState.fromJson(map);
   }
@@ -87,6 +86,7 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// from the context's current track.
   /// [retrievePlaybackState] is optional. If true, the current playback state
   /// will be retrieved. Defaults to true.
+  @Deprecated("Use `startOrResumeTracks` or `startOrResumeContext` instead")
   Future<PlaybackState?> startOrResume(
       {String? deviceId,
       StartOrResumeOptions? options,
@@ -94,10 +94,44 @@ class PlayerEndpoint extends _MeEndpointBase {
     var body = options?.toJson();
     var json = jsonEncode(body ?? '');
 
-    await _api._put(
-        '$_path/play?' + _buildQuery({'device_id': deviceId}), json);
+    await _api._put('$_path/play?${_buildQuery({'device_id': deviceId})}', json);
 
     return retrievePlaybackState ? playbackState() : null;
+  }
+
+  /// Start a new context with given [uris] or resume current playback on the 
+  /// user's active device.
+  /// [deviceId] is optional. If not provided, the user's currently active device
+  /// is the target.
+  /// [uris] is optional. If not provided, playback will start
+  /// from the context's current track.
+  /// [retrievePlaybackState] is optional. If `true`, the current [PlaybackState]
+  /// will be retrieved. Defaults to `true`.
+  Future<PlaybackState?> startOrResumeTracks(
+      {String? deviceId,
+      List<String> uris = const [],
+      int positionMs = 0,
+      bool retrievePlaybackState = true}) async {
+    assert(uris.isNotEmpty, "No uris provided to start of resume playback");
+
+    var options = StartOrResumeOptions(uris: uris, positionMs: positionMs);
+    return startOrResume(
+        deviceId: deviceId,
+        options: options,
+        retrievePlaybackState: retrievePlaybackState);
+  }
+
+    Future<PlaybackState?> startOrResumeContext(
+      {String? deviceId,
+      String? contextUri,
+      Offset? offset,
+      bool retrievePlaybackState = true}) async {
+    
+    var options = StartOrResumeOptions(contextUri: contextUri, offset: offset);
+    return startOrResume(
+        deviceId: deviceId,
+        options: options,
+        retrievePlaybackState: retrievePlaybackState);
   }
 
   /// Pause playback on the user's account.
@@ -107,7 +141,7 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// will be retrieved. Defaults to true.
   Future<PlaybackState?> pause(
       {String? deviceId, bool retrievePlaybackState = true}) async {
-    await _api._put('$_path/pause?' + _buildQuery({'device_id': deviceId}));
+    await _api._put('$_path/pause?${_buildQuery({'device_id': deviceId})}');
 
     return retrievePlaybackState ? playbackState() : null;
   }
@@ -119,7 +153,7 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// will be retrieved. Defaults to true.
   Future<PlaybackState?> previous(
       {String? deviceId, bool retrievePlaybackState = true}) async {
-    await _api._post('$_path/previous?' + _buildQuery({'device_id': deviceId}));
+    await _api._post('$_path/previous?${_buildQuery({'device_id': deviceId})}');
 
     return retrievePlaybackState ? playbackState() : null;
   }
@@ -131,7 +165,7 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// will be retrieved. Defaults to true.
   Future<PlaybackState?> next(
       {String? deviceId, bool retrievePlaybackState = true}) async {
-    await _api._post('$_path/next?' + _buildQuery({'device_id': deviceId}));
+    await _api._post('$_path/next?${_buildQuery({'device_id': deviceId})}');
 
     return retrievePlaybackState ? playbackState() : null;
   }
@@ -145,8 +179,7 @@ class PlayerEndpoint extends _MeEndpointBase {
   Future<PlaybackState?> seek(int positionMs,
       {String? deviceId, bool retrievePlaybackState = true}) async {
     assert(positionMs >= 0, 'positionMs must be greater or equal to 0');
-    await _api._put('$_path/seek?' +
-        _buildQuery({'position_ms': positionMs, 'device_id': deviceId}));
+    await _api._put('$_path/seek?${_buildQuery({'position_ms': positionMs, 'device_id': deviceId})}');
 
     return retrievePlaybackState ? playbackState() : null;
   }
@@ -160,11 +193,10 @@ class PlayerEndpoint extends _MeEndpointBase {
   /// will be retrieved. Defaults to true.
   Future<PlaybackState?> repeat(RepeatState state,
       {String? deviceId, bool retrievePlaybackState = true}) async {
-    await _api._put('$_path/repeat?' +
-        _buildQuery({
+    await _api._put('$_path/repeat?${_buildQuery({
           'state': state.toString().split('.').last,
           'device_id': deviceId
-        }));
+        })}');
 
     return retrievePlaybackState ? playbackState() : null;
   }
@@ -180,8 +212,7 @@ class PlayerEndpoint extends _MeEndpointBase {
       {String? deviceId, bool retrievePlaybackState = true}) async {
     assert(volumePercent >= 0 && volumePercent <= 100,
         'Volume must be between 0 and 100');
-    await _api._put('$_path/volume?' +
-        _buildQuery({'volume_percent': volumePercent, 'device_id': deviceId}));
+    await _api._put('$_path/volume?${_buildQuery({'volume_percent': volumePercent, 'device_id': deviceId})}');
 
     return retrievePlaybackState ? playbackState() : null;
   }

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -546,7 +546,7 @@ PlaybackState _$PlaybackStateFromJson(Map<String, dynamic> json) =>
       ..context = json['context'] == null
           ? null
           : PlayerContext.fromJson(json['context'] as Map<String, dynamic>)
-      ..progress_ms = json['progress_ms'] as int?
+      ..progressMs = json['progress_ms'] as int?
       ..item = json['item'] == null
           ? null
           : Track.fromJson(json['item'] as Map<String, dynamic>)
@@ -576,7 +576,7 @@ const _$RepeatStateEnumMap = {
 
 PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) =>
     PlayerContext()
-      ..external_urls = json['external_urls'] == null
+      ..externalUrls = json['external_urls'] == null
           ? null
           : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
       ..href = json['href'] as String?

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -18,7 +18,8 @@ class PlaybackState extends Object {
   PlayerContext? context;
 
   /// Progress into the currently playing track. Can be `null`.
-  int? progress_ms;
+  @JsonKey(name: 'progress_ms')
+  int? progressMs;
 
   /// The currently playing track. Can be `null`.
   Track? item;
@@ -40,7 +41,7 @@ class PlaybackState extends Object {
   @JsonKey(name: 'shuffle_state', defaultValue: false)
   bool? isShuffling;
 
-  /// The repeat state. Can be [RepeatState.off], [RepeatState.track] or 
+  /// The repeat state. Can be [RepeatState.off], [RepeatState.track] or
   /// [RepeatState.context]
   @JsonKey(name: 'repeat_state', defaultValue: RepeatState.off)
   RepeatState? repeatState;
@@ -55,7 +56,8 @@ class PlayerContext extends Object {
       _$PlayerContextFromJson(json);
 
   /// The external_urls of the context, or `null` if not available.
-  ExternalUrls? external_urls;
+  @JsonKey(name: 'external_urls')
+  ExternalUrls? externalUrls;
 
   /// The href of the context, or `null` if not available.
   String? href;
@@ -125,7 +127,7 @@ class StartOrResumeOptions extends Object {
 
   /// Optional. A JSON array of the Spotify track URIs to play.
   ///
-  /// Example: 
+  /// Example:
   /// ```json
   /// [
   ///     "spotify:track:4iV5W9uYEdYUVa79Axb7Rh",
@@ -148,9 +150,8 @@ class StartOrResumeOptions extends Object {
 
   Map<String, dynamic> toJson() => _$StartOrResumeOptionsToJson(this);
 
-  static Map<String, dynamic> _offsetToJson(Offset? offset) {
-    return offset?.toJson() ?? {};
-  }
+  static Map<String, dynamic> _offsetToJson(Offset? offset) =>
+      offset?.toJson() ?? {};
 }
 
 abstract class Offset {


### PR DESCRIPTION
As discussed, this PR fixes #175 and depracates the method `startOrResume` by splitting its functionality into three new methods:

- `startWithTrackUris`, which starts a new context given a list of `Track` ids
- `startWithContext`, which starts a new context given a `contextUri`
- `resume`, which resumes a current playback

