### PR TITLE
Catching empty response on `PlaybackState`

### DIFF
--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -36,6 +36,9 @@ class PlayerEndpoint extends _MeEndpointBase {
   Future<PlaybackState> playbackState([Market? market]) async {
     var jsonString = await _api
         ._get('$_path?' + _buildQuery({'market': market?.name}));
+    if (jsonString.isEmpty) {
+      return PlaybackState();
+    }
     final map = json.decode(jsonString);
     return PlaybackState.fromJson(map);
   }


### PR DESCRIPTION
Fixes #191. Returns an empty `PlaybackState` object if the response is empty.
@rinukkusu should rather maybe an error be returned instead? E.g.

```dart
Future<PlaybackState> playbackState([Market? market]) async {
    var jsonString = await _api._get(...);
    if (jsonString.isEmpty) {
      return Future.error(SpotifyException('No playback context found'));
    }
...
}
```