### PR TITLE
Expand shortened spotify url

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -12,6 +12,10 @@ void main() async {
   var credentials = SpotifyApiCredentials(keyMap['id'], keyMap['secret']);
   var spotify = SpotifyApi(credentials);
 
+  print('\nExpannd shortened spotify link of https://spotify.link/hRkBrwub9xb');
+  var longLink = await spotify.expandLink('https://spotify.link/hRkBrwub9xb');
+  print(longLink);
+
   print('\nPodcast:');
   await spotify.shows
       .get('4rOoJ6Egrf8K2IrywzwOMk')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ version: 0.12.0
 homepage: https://github.com/rinukkusu/spotify-dart
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  http: ^1.1.0
+  http: ^1.2.0
   json_annotation: ^4.8.1
-  oauth2: ^2.0.0
+  oauth2: ^2.0.2
 
 dev_dependencies:
   lints: ">=2.1.1 <4.0.0"


### PR DESCRIPTION
This PR fixes #154 and adds a new method `spotifyApi.expandLink(shortenedUrl)` to expand shortened links.

In order that to happen the underlying http library has been updated to version `1.2.0`.