### PR TITLE
Offset fix

### DIFF
--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -27,6 +27,7 @@ void main() async {
     exit(0);
   }
   await _user(spotify);
+  await _play(spotify);
   await _currentlyPlaying(spotify);
   await _devices(spotify);
   await _followingArtists(spotify);
@@ -304,6 +305,23 @@ Future<Iterable<Track>> _getPlaylistTracks(
     SpotifyApi spotify, String playlistId) async {
   var tracksPage = spotify.playlists.getTracksByPlaylistId(playlistId);
   return (await tracksPage.first()).items ?? [];
+}
+
+Future<PlaybackState?> _play(SpotifyApi spotify) async {
+  var track = await spotify.tracks.get('6zW80jVqLtgSF1yCtGHiiD');
+  print('Playing "${track.name} - ${track.artists?.first.name}" with track context for 10 s');
+  var result = await spotify.player.startWithTracks(['spotify:track:6zW80jVqLtgSF1yCtGHiiD?si=99fd66ccb2464bad'], positionMs: 10000);
+  sleep(Duration(seconds: 10));
+  print('Pausing...');
+  spotify.player.pause();
+  var album = await spotify.albums.get('0rwbMKjNkp4ehQTwf9V2Jk');
+  track = await spotify.tracks.get('4VnDmjYCZkyeqeb0NIKqdA');
+  print('Playing album "${album.name} - ${album.artists?.first.name}" with uri context');
+  print('and offset to "${track.name} - ${track.artists?.first.name}" for 10 s');
+  result = await spotify.player.startWithContext('spotify:album:0rwbMKjNkp4ehQTwf9V2Jk?si=HA-mX2mPQ1CUp7ExfdDt2g', offset: UriOffset('spotify:track:4VnDmjYCZkyeqeb0NIKqdA'));
+  sleep(Duration(seconds: 10));
+
+  return result;
 }
 
 FutureOr<Null> _prettyPrintError(Object error) {

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -137,7 +137,7 @@ class StartOrResumeOptions extends Object {
   List<String>? uris;
 
   /// Optional. Indicates from where in the context playback should start.
-  /// Only available when context_uri corresponds to an album or playlist object
+  /// Only available when [contextUri] corresponds to an album or playlist object
   @JsonKey(toJson: _offsetToJson)
   Offset? offset;
 
@@ -150,8 +150,7 @@ class StartOrResumeOptions extends Object {
 
   Map<String, dynamic> toJson() => _$StartOrResumeOptionsToJson(this);
 
-  static Map<String, dynamic> _offsetToJson(Offset? offset) =>
-      offset?.toJson() ?? {};
+  static Map<String, dynamic>? _offsetToJson(Offset? offset) => offset?.toJson();
 }
 
 abstract class Offset {


### PR DESCRIPTION
This PR fixes #202 as pointed out by @ILikeRubberDuckies. 
The bug arose, because the json contained an `offset` attribute, when it should be `null`. The `example_auth.dart` now contains testing methods to start playback by `trackIds` or `contextUris`.