### PR TITLE
Refactor `PlayOrResumeOptions`

### DIFF
--- a/lib/src/endpoints/player.dart
+++ b/lib/src/endpoints/player.dart
@@ -126,7 +126,7 @@ class PlayerEndpoint extends _MeEndpointBase {
     assert(trackUris.isNotEmpty, 'Cannot start playback with empty track uris');
     assert(positionMs >= 0, 'Position must be greater than or equal to 0');
 
-    var options = StartOrResumeOptions(uris: trackUris, positionMs: positionMs);
+    var options = StartWithUrisOptions(uris: trackUris, positionMs: positionMs);
     return startOrResume(
         deviceId: deviceId,
         options: options,
@@ -148,7 +148,7 @@ class PlayerEndpoint extends _MeEndpointBase {
       bool retrievePlaybackState = true}) async {
     assert(
         contextUri.isNotEmpty, 'Cannot start playback with empty context uri');
-    var options = StartOrResumeOptions(contextUri: contextUri, offset: offset);
+    var options = StartWithContextOptions(contextUri: contextUri, offset: offset);
     return startOrResume(
         deviceId: deviceId,
         options: options,

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -595,12 +595,17 @@ Actions _$ActionsFromJson(Map<String, dynamic> json) => Actions()
   ..togglingShuffle = json['toggling_shuffle'] as bool? ?? false
   ..transferringPlayback = json['transferring_playback'] as bool? ?? false;
 
-Map<String, dynamic> _$StartOrResumeOptionsToJson(
-        StartOrResumeOptions instance) =>
+Map<String, dynamic> _$StartWithContextOptionsToJson(
+        StartWithContextOptions instance) =>
     <String, dynamic>{
       'context_uri': instance.contextUri,
+      'offset': StartWithContextOptions._offsetToJson(instance.offset),
+    };
+
+Map<String, dynamic> _$StartWithUrisOptionsToJson(
+        StartWithUrisOptions instance) =>
+    <String, dynamic>{
       'uris': instance.uris,
-      'offset': StartOrResumeOptions._offsetToJson(instance.offset),
       'position_ms': instance.positionMs,
     };
 

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -117,13 +117,35 @@ class Actions extends Object {
   bool? transferringPlayback;
 }
 
+abstract class StartOrResumeOptions extends Object {
+  Map<String, dynamic> toJson();
+}
+
 @JsonSerializable(createFactory: false)
-class StartOrResumeOptions extends Object {
+class StartWithContextOptions extends StartOrResumeOptions {
+  StartWithContextOptions({this.contextUri, this.offset});
+
   /// Optional. Spotify URI of the context to play. Valid contexts are albums,
   /// artists & playlists.
   /// Example: "spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"
   @JsonKey(name: 'context_uri')
   String? contextUri;
+
+  /// Optional. Indicates from where in the context playback should start.
+  /// Only available when [contextUri] corresponds to an album or playlist object
+  @JsonKey(toJson: _offsetToJson)
+  Offset? offset;
+
+  @override
+  Map<String, dynamic> toJson() => _$StartWithContextOptionsToJson(this);
+
+  static Map<String, dynamic>? _offsetToJson(Offset? offset) =>
+      offset?.toJson();
+}
+
+@JsonSerializable(createFactory: false)
+class StartWithUrisOptions extends StartOrResumeOptions {
+  StartWithUrisOptions({this.uris, this.positionMs});
 
   /// Optional. A JSON array of the Spotify track URIs to play.
   ///
@@ -136,22 +158,12 @@ class StartOrResumeOptions extends Object {
   /// ```
   List<String>? uris;
 
-  /// Optional. Indicates from where in the context playback should start.
-  /// Only available when context_uri corresponds to an album or playlist object
-  @JsonKey(toJson: _offsetToJson)
-  Offset? offset;
-
   /// Optional. The position in milliseconds to start playback.
   @JsonKey(name: 'position_ms')
   int? positionMs;
 
-  StartOrResumeOptions(
-      {this.contextUri, this.uris, this.offset, this.positionMs});
-
-  Map<String, dynamic> toJson() => _$StartOrResumeOptionsToJson(this);
-
-  static Map<String, dynamic> _offsetToJson(Offset? offset) =>
-      offset?.toJson() ?? {};
+  @override
+  Map<String, dynamic> toJson() => _$StartWithUrisOptionsToJson(this);
 }
 
 abstract class Offset {

--- a/lib/src/models/player.dart
+++ b/lib/src/models/player.dart
@@ -123,6 +123,7 @@ abstract class StartOrResumeOptions extends Object {
 
 @JsonSerializable(createFactory: false)
 class StartWithContextOptions extends StartOrResumeOptions {
+
   StartWithContextOptions({this.contextUri, this.offset});
 
   /// Optional. Spotify URI of the context to play. Valid contexts are albums,
@@ -145,6 +146,7 @@ class StartWithContextOptions extends StartOrResumeOptions {
 
 @JsonSerializable(createFactory: false)
 class StartWithUrisOptions extends StartOrResumeOptions {
+
   StartWithUrisOptions({this.uris, this.positionMs});
 
   /// Optional. A JSON array of the Spotify track URIs to play.
@@ -158,21 +160,13 @@ class StartWithUrisOptions extends StartOrResumeOptions {
   /// ```
   List<String>? uris;
 
-  /// Optional. Indicates from where in the context playback should start.
-  /// Only available when [contextUri] corresponds to an album or playlist object
-  @JsonKey(toJson: _offsetToJson)
-  Offset? offset;
-
   /// Optional. The position in milliseconds to start playback.
   @JsonKey(name: 'position_ms')
   int? positionMs;
 
-  StartOrResumeOptions(
-      {this.contextUri, this.uris, this.offset, this.positionMs});
+  @override
+  Map<String, dynamic> toJson() => _$StartWithUrisOptionsToJson(this);
 
-  Map<String, dynamic> toJson() => _$StartOrResumeOptionsToJson(this);
-
-  static Map<String, dynamic>? _offsetToJson(Offset? offset) => offset?.toJson();
 }
 
 abstract class Offset {

--- a/test/data/v1/me/player/play.json
+++ b/test/data/v1/me/player/play.json
@@ -1,0 +1,93 @@
+{
+    "device": {
+      "id": "123",
+      "is_active": true,
+      "is_private_session": false,
+      "is_restricted": false,
+      "name": "spotify-player",
+      "supports_volume": true,
+      "type": "Speaker",
+      "volume_percent": 50
+    },
+    "shuffle_state": false,
+    "smart_shuffle": false,
+    "repeat_state": "off",
+    "timestamp": 1708246313962,
+    "context": null,
+    "progress_ms": 96749,
+    "item": {
+      "album": {
+        "album_type": "album",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "https://open.spotify.com/artist/0OcclcP5o8VKH2TRqSY2A7"
+            },
+            "href": "https://api.spotify.com/v1/artists/0OcclcP5o8VKH2TRqSY2A7",
+            "id": "0OcclcP5o8VKH2TRqSY2A7",
+            "name": "Howard Shore",
+            "type": "artist",
+            "uri": "spotify:artist:0OcclcP5o8VKH2TRqSY2A7"
+          }
+        ],
+        "available_markets": ["AR"],
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/55RTkgUCP7t80hiTUhATMH"
+        },
+        "href": "https://api.spotify.com/v1/albums/55RTkgUCP7t80hiTUhATMH",
+        "id": "55RTkgUCP7t80hiTUhATMH",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab67616d0000b2738236dee9524214e0e6be4a1f",
+            "width": 640
+          }
+        ],
+        "name": "The Lord of the Rings: The Fellowship of the Ring - the Complete Recordings",
+        "release_date": "2001",
+        "release_date_precision": "year",
+        "total_tracks": 37,
+        "type": "album",
+        "uri": "spotify:album:55RTkgUCP7t80hiTUhATMH"
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0OcclcP5o8VKH2TRqSY2A7"
+          },
+          "href": "https://api.spotify.com/v1/artists/0OcclcP5o8VKH2TRqSY2A7",
+          "id": "0OcclcP5o8VKH2TRqSY2A7",
+          "name": "Howard Shore",
+          "type": "artist",
+          "uri": "spotify:artist:0OcclcP5o8VKH2TRqSY2A7"
+        }
+      ],
+      "available_markets": ["AR"],
+      "disc_number": 1,
+      "duration_ms": 149480,
+      "explicit": false,
+      "external_ids": {
+        "isrc": "USRE10501559"
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/6zW80jVqLtgSF1yCtGHiiD"
+      },
+      "href": "https://api.spotify.com/v1/tracks/6zW80jVqLtgSF1yCtGHiiD",
+      "id": "6zW80jVqLtgSF1yCtGHiiD",
+      "is_local": false,
+      "name": "The Shire",
+      "popularity": 66,
+      "preview_url": "https://p.scdn.co/mp3-preview/0cb0d3080071ec5c911ea209ec4fc2258e2081d6?cid=a51c360ccea644af8e2a0b1baad8a878",
+      "track_number": 2,
+      "type": "track",
+      "uri": "spotify:track:6zW80jVqLtgSF1yCtGHiiD"
+    },
+    "currently_playing_type": "track",
+    "actions": {
+      "disallows": {
+        "skipping_prev": true,
+        "toggling_repeat_track": true
+      }
+    },
+    "is_playing": false
+  }

--- a/test/spotify_mock.dart
+++ b/test/spotify_mock.dart
@@ -12,6 +12,9 @@ class SpotifyApiMock extends SpotifyApiBase {
 
   set mockHttpErrors(Iterator<MockHttpError> errors) =>
       (client as MockClient)._mockHttpErrors = errors;
+  
+  set interceptor(Function(String method, String url, Map<String, String>? headers, [String? body])? interceptor) => 
+      (client as MockClient).interceptFunction = interceptor;
 }
 
 class MockClient implements oauth2.Client {
@@ -20,6 +23,14 @@ class MockClient implements oauth2.Client {
     identifier = credentials.clientId;
     secret = credentials.clientSecret;
     _mockHttpErrors = mockHttpErrors;
+  }
+
+  Function(String method, String url, Map<String, String>? headers, [String? body])? interceptFunction;  
+
+  void _intercept(String method, String url, Map<String, String>? headers, [String? body]) {
+    if (interceptFunction != null) {
+      interceptFunction!(method, url, headers, body);
+    }
   }
 
   @override
@@ -63,6 +74,7 @@ class MockClient implements oauth2.Client {
 
   @override
   Future<http.Response> get(url, {Map<String, String>? headers}) async {
+    _intercept('GET', url.toString(), headers);
     final err = _getMockError();
     if (err != null) {
       return createErrorResponse(err);
@@ -71,8 +83,9 @@ class MockClient implements oauth2.Client {
   }
 
   @override
-  Future<http.Response> head(url, {Map<String, String>? headers}) {
-    throw 'Not implemented';
+  Future<http.Response> head(url, {Map<String, String>? headers}) async {
+    _intercept('HEAD', url.toString(), headers);
+    return createSuccessResponse();
   }
 
   @override
@@ -84,6 +97,7 @@ class MockClient implements oauth2.Client {
   @override
   Future<http.Response> post(url,
       {Map<String, String>? headers, body, Encoding? encoding}) async {
+    _intercept('POST', url.toString(), headers, body.toString());
     final err = _getMockError();
     if (err != null) {
       return createErrorResponse(err);
@@ -93,8 +107,9 @@ class MockClient implements oauth2.Client {
 
   @override
   Future<http.Response> put(url,
-      {Map<String, String>? headers, body, Encoding? encoding}) {
-    throw 'Not implemented';
+      {Map<String, String>? headers, body, Encoding? encoding}) async {
+        _intercept('PUT', url.toString(), headers, body.toString());
+    return createSuccessResponse(_readPath(url));
   }
 
   @override
@@ -126,7 +141,7 @@ class MockClient implements oauth2.Client {
     throw 'Not implemented';
   }
 
-  http.Response createSuccessResponse(String body) {
+  http.Response createSuccessResponse([String body = ""]) {
     /// necessary due to using Latin-1 encoding per default.
     /// https://stackoverflow.com/questions/52990816/dart-json-encodedata-can-not-accept-other-language
     return http.Response(body, 200, headers: {

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'spotify_mock.dart';
 import 'package:test/test.dart';
 import 'package:spotify/spotify.dart';
@@ -8,6 +9,10 @@ Future main() async {
     'clientId',
     'clientSecret',
   ));
+
+  tearDown(() {
+    spotify.interceptor = null;
+  });
 
   group('Albums', () {
     test('get', () async {
@@ -480,6 +485,34 @@ Future main() async {
       expect(result.actions?.resuming, false);
       expect(result.actions?.pausing, true);
     });
+
+
+    test('startWithContext', () async {
+      spotify.interceptor = (method, url, headers, [body]) {
+        // checking sincce startWithContext makes a PUT and a GET request
+        // to retrieve the current playbackstate
+        if (method == 'PUT') {
+          expect(method, 'PUT');
+          expect(body, isNotNull);
+          expect(body, '{"context_uri":"contextUri","offset":{"uri":"urioffset"}}');
+        }
+      };
+      await spotify.player.startWithContext('contextUri', offset: UriOffset('urioffset'));
+    });
+
+    test('startWithUris', () async {
+      spotify.interceptor = (method, url, headers, [body]) {
+        // checking sincce startWithTracks makes a PUT and a GET request
+        // to retrieve the current playbackstate
+        if (method == 'PUT') {
+          expect(method, 'PUT');
+          expect(body, isNotNull);
+          expect(body, '{"uris":["track1"],"position_ms":10}');
+        }
+      };
+      await spotify.player.startWithTracks(['track1'], positionMs: 10);
+    });
+
   });
 
   group('Tracks', () {


### PR DESCRIPTION
Since the json attributes of the `PlayOrResumeOptions` must be disjointed, two new classes have been implemented to keep unnecessary attributes out of the request body. This is the consequence of #202. 

Furthermore, in order to test `PUT`, `POST` or `DELETE` http methods, a very rudiment interceptor has been added.