### PR TITLE
`SpotifyApi.authorizationCodeGrant`: add parameter `codeVerifier`.

### DIFF
--- a/lib/src/spotify_api.dart
+++ b/lib/src/spotify_api.dart
@@ -40,8 +40,10 @@ class SpotifyApi extends SpotifyApiBase {
 
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
       SpotifyApiCredentials credentials,
-      {Function(SpotifyApiCredentials)? onCredentialsRefreshed}) {
-    return SpotifyApiBase.authorizationCodeGrant(
-        credentials, http.Client(), onCredentialsRefreshed);
+      {String? codeVerifier,
+      Function(SpotifyApiCredentials)? onCredentialsRefreshed}) {
+    return SpotifyApiBase.authorizationCodeGrant(credentials, http.Client(),
+        codeVerifier: codeVerifier,
+        onCredentialsRefreshed: onCredentialsRefreshed);
   }
 }

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -12,37 +12,54 @@ abstract class SpotifyApiBase {
   bool _shouldWait = false;
   late FutureOr<oauth2.Client> _client;
   late Artists _artists;
+
   Artists get artists => _artists;
   late Albums _albums;
+
   Albums get albums => _albums;
   late Browse _browse;
+
   Browse get browse => _browse;
   late Tracks _tracks;
+
   Tracks get tracks => _tracks;
   late Playlists _playlists;
+
   Playlists get playlists => _playlists;
   late Episodes _episodes;
+
   Episodes get episodes => _episodes;
   late RecommendationsEndpoint _recommendations;
+
   RecommendationsEndpoint get recommendations => _recommendations;
   late Markets _markets;
+
   Markets get markets => _markets;
   late Users _users;
+
   Users get users => _users;
   late Search _search;
+
   Search get search => _search;
   late AudioFeatures _audioFeatures;
+
   AudioFeatures get audioFeatures => _audioFeatures;
   late AudioAnalysisEndpoint _audioAnalysis;
+
   AudioAnalysisEndpoint get audioAnalysis => _audioAnalysis;
   late Categories _categories;
+
   Categories get categories => _categories;
   late Me _me;
+
   Me get me => _me;
   late PlayerEndpoint _player;
+
   PlayerEndpoint get player => _player;
   late Shows _shows;
+
   Shows get shows => _shows;
+
   FutureOr<oauth2.Client> get client => _client;
 
   SpotifyApiBase.fromClient(FutureOr<http.BaseClient> client) {
@@ -94,14 +111,16 @@ abstract class SpotifyApiBase {
 
   static oauth2.AuthorizationCodeGrant authorizationCodeGrant(
       SpotifyApiCredentials credentials, http.Client httpClient,
-      [Function(SpotifyApiCredentials)? callBack]) {
+      {String? codeVerifier,
+      Function(SpotifyApiCredentials)? onCredentialsRefreshed}) {
     return oauth2.AuthorizationCodeGrant(
         credentials.clientId!,
         Uri.parse(SpotifyApiBase._authorizationUrl),
         Uri.parse(SpotifyApiBase._tokenUrl),
         secret: credentials.clientSecret,
+        codeVerifier: codeVerifier,
         httpClient: httpClient,
-        onCredentialsRefreshed: callBack != null
+        onCredentialsRefreshed: onCredentialsRefreshed != null
             ? (oauth2.Credentials cred) {
                 final newCredentials = SpotifyApiCredentials(
                     credentials.clientId, credentials.clientSecret,
@@ -109,7 +128,7 @@ abstract class SpotifyApiBase {
                     expiration: cred.expiration,
                     refreshToken: cred.refreshToken,
                     scopes: cred.scopes);
-                callBack(newCredentials);
+                onCredentialsRefreshed(newCredentials);
               }
             : null);
   }
@@ -159,7 +178,8 @@ abstract class SpotifyApiBase {
   }
 
   /// Expands shortened spotify [url]
-  Future<String> expandLink(String url) async => _streamedHeadImpl(url, const {});
+  Future<String> expandLink(String url) async =>
+      _streamedHeadImpl(url, const {});
 
   Future<String> _get(String path) {
     return _getImpl('$_baseUrl/$path', const {});
@@ -225,13 +245,13 @@ abstract class SpotifyApiBase {
       }
       try {
         var response = await request();
-        
+
         // distinguish between url redirect responses and body responses
         // note, that any response that also contains a redirect url
         // will be chosen instead of its body contents
         // FIXME: in future releases of http2, the url is a part of the [http.Response] type
         if (response case http.BaseResponseWithUrl(:final url)) {
-            return url.toString();
+          return url.toString();
         }
         return handleResponseWithBody(response as http.Response);
       } on ApiRateException catch (ex) {

--- a/lib/src/spotify_base.dart
+++ b/lib/src/spotify_base.dart
@@ -10,57 +10,57 @@ abstract class SpotifyApiBase {
       'https://accounts.spotify.com/authorize';
 
   bool _shouldWait = false;
-  late FutureOr<oauth2.Client> _client;
-  late Artists _artists;
-
-  Artists get artists => _artists;
-  late Albums _albums;
-
-  Albums get albums => _albums;
-  late Browse _browse;
-
-  Browse get browse => _browse;
-  late Tracks _tracks;
-
-  Tracks get tracks => _tracks;
-  late Playlists _playlists;
-
-  Playlists get playlists => _playlists;
-  late Episodes _episodes;
-
-  Episodes get episodes => _episodes;
-  late RecommendationsEndpoint _recommendations;
-
-  RecommendationsEndpoint get recommendations => _recommendations;
-  late Markets _markets;
-
-  Markets get markets => _markets;
-  late Users _users;
-
-  Users get users => _users;
-  late Search _search;
-
-  Search get search => _search;
-  late AudioFeatures _audioFeatures;
-
-  AudioFeatures get audioFeatures => _audioFeatures;
-  late AudioAnalysisEndpoint _audioAnalysis;
-
-  AudioAnalysisEndpoint get audioAnalysis => _audioAnalysis;
-  late Categories _categories;
-
-  Categories get categories => _categories;
-  late Me _me;
-
-  Me get me => _me;
-  late PlayerEndpoint _player;
-
-  PlayerEndpoint get player => _player;
-  late Shows _shows;
-
-  Shows get shows => _shows;
-
+  
+  late FutureOr<oauth2.Client> _client;  
   FutureOr<oauth2.Client> get client => _client;
+  
+  late Artists _artists;
+  Artists get artists => _artists;
+  
+  late Albums _albums;
+  Albums get albums => _albums;
+  
+  late Browse _browse;
+  Browse get browse => _browse;
+  
+  late Tracks _tracks;
+  Tracks get tracks => _tracks;
+  
+  late Playlists _playlists;
+  Playlists get playlists => _playlists;
+  
+  late Episodes _episodes;
+  Episodes get episodes => _episodes;
+  
+  late RecommendationsEndpoint _recommendations;
+  RecommendationsEndpoint get recommendations => _recommendations;
+  
+  late Markets _markets;
+  Markets get markets => _markets;
+  
+  late Users _users;
+  Users get users => _users;
+  
+  late Search _search;
+  Search get search => _search;
+  
+  late AudioFeatures _audioFeatures;
+  AudioFeatures get audioFeatures => _audioFeatures;
+  
+  late AudioAnalysisEndpoint _audioAnalysis;
+  AudioAnalysisEndpoint get audioAnalysis => _audioAnalysis;
+  
+  late Categories _categories;
+  Categories get categories => _categories;
+  
+  late Me _me;
+  Me get me => _me;
+  
+  late PlayerEndpoint _player;
+  PlayerEndpoint get player => _player;
+  
+  late Shows _shows;
+  Shows get shows => _shows;
 
   SpotifyApiBase.fromClient(FutureOr<http.BaseClient> client) {
     _client = client as FutureOr<oauth2.Client>;


### PR DESCRIPTION
Expose `codeVerifier` when building `AuthorizationCodeGrant` from `SpotifyApi.authorizationCodeGrant`.

Issue: https://github.com/rinukkusu/spotify-dart/issues/201