### PR TITLE
replace user-read-profile with user-read-private in AuthorizationScope

### DIFF
--- a/lib/src/authorization_scope.dart
+++ b/lib/src/authorization_scope.dart
@@ -174,10 +174,10 @@ class UserAuthorizationScope extends _Scope {
 
   /// Read access to user’s subscription details (type of user account).
   ///
-  /// Endpoints that require the `user-read-profile` scope:
+  /// Endpoints that require the `user-read-private` scope:
   /// * [Search.get]
   /// * [Me.get]
-  String get readFollow => 'user-read-profile';
+  String get readPrivate => 'user-read-private';
 
   /// Read access to user’s email address.
   ///
@@ -187,7 +187,7 @@ class UserAuthorizationScope extends _Scope {
 
   /// Contains all properties of [AuthorizationScope.user]
   @override
-  List<String> get all => List.unmodifiable([readFollow, readEmail]);
+  List<String> get all => List.unmodifiable([readPrivate, readEmail]);
 }
 
 class PlaylistAuthorizationScope extends _Scope {


### PR DESCRIPTION
There's no `user-read-profile` in [spotify scopes](https://developer.spotify.com/documentation/web-api/concepts/scopes) so `illegal scope` is fired during authorization.

Now we can fetch user information like market, product (free, premium), and email.




