### PR TITLE
Make tracks in getTracksByPlaylistId nullable

### DIFF
--- a/example/example_auth.dart
+++ b/example/example_auth.dart
@@ -259,12 +259,12 @@ Future<void> _clearPlaylist(SpotifyApi spotify) async {
   print('Clearing Playlist');
   var playlist = await _createPrivatePlaylist(spotify);
   var tracks = await _getPlaylistTracks(spotify, playlist.id ?? '');
-  print('Tracks before: ${tracks.map((e) => e.name)}');
+  print('Tracks before: ${tracks.map((e) => e?.name)}');
 
   await spotify.playlists.clear(playlist.id ?? '');
 
   tracks = await _getPlaylistTracks(spotify, playlist.id ?? '');
-  print('Tracks after: ${tracks.map((e) => e.name)}');
+  print('Tracks after: ${tracks.map((e) => e?.name)}');
 
   await _removePrivatePlaylist(spotify, playlist.id ?? '');
 }
@@ -274,14 +274,14 @@ Future<void> _reorderItemsInPlaylist(SpotifyApi spotify) async {
   var playlist = await _createPrivatePlaylist(spotify);
   var playlistId = playlist.id ?? '';
   var tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks before: ${tracks.map((e) => e.name)}');
+  print('Tracks before: ${tracks.map((e) => e?.name)}');
 
   // reorders the first element to the end of the playlist
   await spotify.playlists
       .reorder(playlistId, rangeStart: 0, insertBefore: tracks.length);
 
   tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks after: ${tracks.map((e) => e.name)}');
+  print('Tracks after: ${tracks.map((e) => e?.name)}');
 
   await _removePrivatePlaylist(spotify, playlist.id ?? '');
 }
@@ -291,18 +291,18 @@ Future<void> _replaceItemsInPlaylist(SpotifyApi spotify) async {
   var playlist = await _createPrivatePlaylist(spotify);
   var playlistId = playlist.id ?? '';
   var tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks before: ${tracks.map((e) => e.name)}');
+  print('Tracks before: ${tracks.map((e) => e?.name)}');
 
   // replaces the whole playlist with only the first item
-  await spotify.playlists.replace(playlistId, [tracks.first.uri ?? '']);
+  await spotify.playlists.replace(playlistId, [tracks.first?.uri ?? '']);
 
   tracks = await _getPlaylistTracks(spotify, playlistId);
-  print('Tracks after: ${tracks.map((e) => e.name)}');
+  print('Tracks after: ${tracks.map((e) => e?.name)}');
 
   await _removePrivatePlaylist(spotify, playlist.id ?? '');
 }
 
-Future<Iterable<Track>> _getPlaylistTracks(
+Future<Iterable<Track?>> _getPlaylistTracks(
     SpotifyApi spotify, String playlistId) async {
   var tracksPage = spotify.playlists.getTracksByPlaylistId(playlistId);
   return (await tracksPage.first()).items ?? [];

--- a/lib/src/endpoints/playlists.dart
+++ b/lib/src/endpoints/playlists.dart
@@ -36,11 +36,13 @@ class Playlists extends EndpointPaging {
   }
 
   /// Returns `track`s from a given spotify [playlistId]
-  Pages<Track> getTracksByPlaylistId(playlistId) {
+  Pages<Track?> getTracksByPlaylistId(playlistId) {
     // restricting the return items to `track`
     final query = _buildQuery({'additional_types': 'track'});
-    return _getPages('v1/playlists/$playlistId/tracks?$query',
-        (json) => Track.fromJson(json['track']));
+    return _getPages('v1/playlists/$playlistId/tracks?$query', (json) {
+      var trackJson = json['track'];
+      return trackJson != null ? Track.fromJson(trackJson) : null;
+    });
   }
 
   /// [userId] - the Spotify user ID


### PR DESCRIPTION
Currently, the `Playlists.getTracksByPlaylistId` returns a `Pages<Track>`. This is wrong, as the `track` attribute in the returned responses can actually be `null`. This can happen in cases where songs on a playlist are not available anymore.

This fix aims to fix this bug by simply changing the result to a `Pages<Track?>`. Thus, the result can handle these missing tracks by replacing them with `null` values.

I am aware that this is a breaking change, however in my opinion it is the correct way to handle this. Another option would be to filter out tracks that are null, but that would require a modification of `_getPages` to be able to pass a filter function that removes items that match that filter. If you prefer that solution, I can update the PR accordingly.