### PR TITLE
Change PlayHistory and Recommendations to use Track instead of TrackSimple

### DIFF
--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -1010,7 +1010,7 @@ Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) =>
           ?.map((e) => RecommendationsSeed.fromJson(e as Map<String, dynamic>))
           .toList()
       ..tracks = (json['tracks'] as List<dynamic>?)
-          ?.map((e) => TrackSimple.fromJson(e as Map<String, dynamic>))
+          ?.map((e) => Track.fromJson(e as Map<String, dynamic>))
           .toList();
 
 Map<String, dynamic> _$RecommendationsToJson(Recommendations instance) =>
@@ -1385,7 +1385,7 @@ Map<String, dynamic> _$UserPublicToJson(UserPublic instance) =>
 PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) => PlayHistory()
   ..track = json['track'] == null
       ? null
-      : TrackSimple.fromJson(json['track'] as Map<String, dynamic>)
+      : Track.fromJson(json['track'] as Map<String, dynamic>)
   ..playedAt = json['played_at'] == null
       ? null
       : DateTime.parse(json['played_at'] as String)

--- a/lib/src/models/recommendations.dart
+++ b/lib/src/models/recommendations.dart
@@ -13,9 +13,9 @@ class Recommendations extends Object {
   /// A List of [RecommendationsSeed] objects.
   List<RecommendationsSeed>? seeds;
 
-  /// A List of [TrackSimple] objects ordered according to the parameters
+  /// A List of [Track] objects ordered according to the parameters
   /// supplied.
-  List<TrackSimple>? tracks;
+  List<Track>? tracks;
 }
 
 /// Json representation of the recommendation seed

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -123,7 +123,7 @@ class PlayHistory extends Object {
   Map<String, dynamic> toJson() => _$PlayHistoryToJson(this);
 
   /// The track the user listened to.
-  TrackSimple? track;
+  Track? track;
 
   /// The date and time the track was played.
   @JsonKey(name: 'played_at')

--- a/test/data/v1/me/player/recently-played.json
+++ b/test/data/v1/me/player/recently-played.json
@@ -31,7 +31,54 @@
           "preview_url": "https://p.scdn.co/mp3-preview/6023e5aac2123d098ce490488966b28838b14fa2",
           "track_number": 9,
           "type": "track",
-          "uri": "spotify:track:2gNfxysfBRfl9Lvi9T3v6R"
+          "uri": "spotify:track:2gNfxysfBRfl9Lvi9T3v6R",
+          "album": {
+            "album_type": "album",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+                },
+                "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+                "id": "5INjqkS1o8h1imAzPqGZBb",
+                "name": "Tame Impala",
+                "type": "artist",
+                "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/79dL7FLiJFOO0EoehUHQBv"
+            },
+            "href": "https://api.spotify.com/v1/albums/79dL7FLiJFOO0EoehUHQBv",
+            "id": "79dL7FLiJFOO0EoehUHQBv",
+            "images": [
+              {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab67616d0000b2739e1cfc756886ac782e363d79",
+                "width": 640
+              },
+              {
+                "height": 300,
+                "url": "https://i.scdn.co/image/ab67616d00001e029e1cfc756886ac782e363d79",
+                "width": 300
+              },
+              {
+                "height": 64,
+                "url": "https://i.scdn.co/image/ab67616d000048519e1cfc756886ac782e363d79",
+                "width": 64
+              }
+            ],
+            "name": "Currents",
+            "release_date": "2015-07-17",
+            "release_date_precision": "day",
+            "total_tracks": 13,
+            "type": "album",
+            "uri": "spotify:album:79dL7FLiJFOO0EoehUHQBv"
+          },
+          "popularity": 75,
+          "external_ids": {
+            "isrc": "GBAHT1500338"
+          }
         },
         "played_at": "2016-12-13T20:44:04.589Z",
         "context": {
@@ -74,7 +121,54 @@
           "preview_url": "https://p.scdn.co/mp3-preview/05dee1ad0d2a6fa4ad07fbd24ae49d58468e8194",
           "track_number": 1,
           "type": "track",
-          "uri": "spotify:track:2X485T9Z5Ly0xyaghN73ed"
+          "uri": "spotify:track:2X485T9Z5Ly0xyaghN73ed",
+          "album": {
+            "album_type": "album",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "https://open.spotify.com/artist/5INjqkS1o8h1imAzPqGZBb"
+                },
+                "href": "https://api.spotify.com/v1/artists/5INjqkS1o8h1imAzPqGZBb",
+                "id": "5INjqkS1o8h1imAzPqGZBb",
+                "name": "Tame Impala",
+                "type": "artist",
+                "uri": "spotify:artist:5INjqkS1o8h1imAzPqGZBb"
+              }
+            ],
+            "external_urls": {
+              "spotify": "https://open.spotify.com/album/79dL7FLiJFOO0EoehUHQBv"
+            },
+            "href": "https://api.spotify.com/v1/albums/79dL7FLiJFOO0EoehUHQBv",
+            "id": "79dL7FLiJFOO0EoehUHQBv",
+            "images": [
+              {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab67616d0000b2739e1cfc756886ac782e363d79",
+                "width": 640
+              },
+              {
+                "height": 300,
+                "url": "https://i.scdn.co/image/ab67616d00001e029e1cfc756886ac782e363d79",
+                "width": 300
+              },
+              {
+                "height": 64,
+                "url": "https://i.scdn.co/image/ab67616d000048519e1cfc756886ac782e363d79",
+                "width": 64
+              }
+            ],
+            "name": "Currents",
+            "release_date": "2015-07-17",
+            "release_date_precision": "day",
+            "total_tracks": 13,
+            "type": "album",
+            "uri": "spotify:album:79dL7FLiJFOO0EoehUHQBv"
+          },
+          "popularity": 82,
+          "external_ids": {
+            "isrc": "GBAHT1500325"
+          }
         },
         "played_at": "2016-12-13T20:42:17.016Z",
         "context": {

--- a/test/spotify_test.dart
+++ b/test/spotify_test.dart
@@ -359,6 +359,12 @@ Future main() async {
       expect(firstTrack.artists!.length, 1);
       expect(firstTrack.artists!.first.name, 'Tame Impala');
 
+      // test album and popularity fields (Track instead of TrackSimple)
+      expect(firstTrack.album != null, true);
+      expect(firstTrack.album!.name, 'Currents');
+      expect(firstTrack.album!.id, '79dL7FLiJFOO0EoehUHQBv');
+      expect(firstTrack.popularity, 75);
+
       var second = result.last;
       expect(second.playedAt, DateTime.tryParse('2016-12-13T20:42:17.016Z'));
       expect(second.context!.uri, 'spotify:artist:5INjqkS1o8h1imAzPqGZBb');


### PR DESCRIPTION
## Summary

This PR updates the `PlayHistory` and `Recommendations` models to use the full `Track` object instead of `TrackSimple`, accurately reflecting what the Spotify API actually returns.

## Changes

- **PlayHistory.track**: Changed from `TrackSimple?` to `Track?`
- **Recommendations.tracks**: Changed from `List<TrackSimple>?` to `List<Track>?`
- Updated test fixture with album and popularity fields
- Added test assertions to verify the new fields
- Regenerated JSON serialization code

Fixes #221
Fixes #170
Fixes #176