### PR TITLE
[Refactor model classes] Adds Base classes and first inheritances

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -80,7 +80,7 @@ void main() async {
             'name: ${item.name}:\n'
             'collaborative: ${item.collaborative}\n'
             'href: ${item.href}\n'
-            'trackslink: ${item.tracksLink!.href}\n'
+            'trackslink: ${item.tracks!.href}\n'
             'owner: ${item.owner}\n'
             'public: ${item.owner}\n'
             'snapshotId: ${item.snapshotId}\n'

--- a/lib/src/models/_base.dart
+++ b/lib/src/models/_base.dart
@@ -1,0 +1,35 @@
+part of '_models.dart';
+
+/// Base class for any spotify model
+abstract class SpotifyContentBase {
+  /// A link to the Web API endpoint providing full details of the content.
+  String? href;
+
+  /// The Spotify ID for this given content.
+  String? id;
+}
+
+/// Base class for any
+abstract class SpotifyContent extends SpotifyContentBase {
+  /// The Spotify URI for the show.
+  String? uri;
+
+  /// The [SpotifyContentType] of this content. Can be either
+  /// * [SpotifyContentType.album]
+  /// * [SpotifyContentType.track]
+  /// * [SpotifyContentType.playlist]
+  /// * [SpotifyContentType.episode] or
+  /// * [SpotifyContentType.show]
+  SpotifyContentType? type;
+}
+
+abstract class SpotifyContentCollection<T> {
+  T? content;
+}
+
+abstract class FeaturedContent<T> extends SpotifyContentCollection<T> {
+  /// The message of the day for Spotify's featured playlists
+  String? message;
+}
+
+enum SpotifyContentType { album, track, playlist, episode, show }

--- a/lib/src/models/_models.dart
+++ b/lib/src/models/_models.dart
@@ -5,6 +5,7 @@ part '_models.g.dart';
 
 part 'external_objects.dart';
 
+part '_base.dart';
 part 'album.dart';
 part 'artist.dart';
 part 'audio_analysis.dart';

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -6,11 +6,9 @@ part of '_models.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-ExternalUrls _$ExternalUrlsFromJson(Map<String, dynamic> json) =>
-    ExternalUrls()..spotify = json['spotify'] as String?;
+ExternalUrls _$ExternalUrlsFromJson(Map<String, dynamic> json) => ExternalUrls()..spotify = json['spotify'] as String?;
 
-Map<String, dynamic> _$ExternalUrlsToJson(ExternalUrls instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ExternalUrlsToJson(ExternalUrls instance) => <String, dynamic>{
       'spotify': instance.spotify,
     };
 
@@ -19,8 +17,7 @@ ExternalIds _$ExternalIdsFromJson(Map<String, dynamic> json) => ExternalIds()
   ..ean = json['ean'] as String?
   ..upc = json['upc'] as String?;
 
-Map<String, dynamic> _$ExternalIdsToJson(ExternalIds instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ExternalIdsToJson(ExternalIds instance) => <String, dynamic>{
       'isrc': instance.isrc,
       'ean': instance.ean,
       'upc': instance.upc,
@@ -28,51 +25,39 @@ Map<String, dynamic> _$ExternalIdsToJson(ExternalIds instance) =>
 
 Album _$AlbumFromJson(Map<String, dynamic> json) => Album()
   ..albumType = AlbumSimple._convertForAlbumType(json['album_type'] as String?)
-  ..artists = (json['artists'] as List<dynamic>?)
-      ?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
-      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
-      .toList()
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>)).toList()
+  ..availableMarkets =
+      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..name = json['name'] as String?
   ..releaseDate = json['release_date'] as String?
-  ..releaseDatePrecision = $enumDecodeNullable(
-      _$DatePrecisionEnumMap, json['release_date_precision'])
+  ..releaseDatePrecision = $enumDecodeNullable(_$DatePrecisionEnumMap, json['release_date_precision'])
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
   ..tracks = AlbumSimple._extractTracksFromPage(json['tracks'])
-  ..copyrights = (json['copyrights'] as List<dynamic>?)
-      ?.map((e) => Copyright.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..externalIds = json['external_ids'] == null
-      ? null
-      : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
-  ..genres =
-      (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..copyrights =
+      (json['copyrights'] as List<dynamic>?)?.map((e) => Copyright.fromJson(e as Map<String, dynamic>)).toList()
+  ..externalIds =
+      json['external_ids'] == null ? null : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
+  ..genres = (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..label = json['label'] as String?
   ..popularity = convertToIntIfDoubleValue(json['popularity']);
 
 Map<String, dynamic> _$AlbumToJson(Album instance) => <String, dynamic>{
       'album_type': _$AlbumTypeEnumMap[instance.albumType],
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets':
-          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'images': instance.images?.map((e) => e.toJson()).toList(),
       'name': instance.name,
       'release_date': instance.releaseDate,
-      'release_date_precision':
-          _$DatePrecisionEnumMap[instance.releaseDatePrecision],
+      'release_date_precision': _$DatePrecisionEnumMap[instance.releaseDatePrecision],
       'type': instance.type,
       'uri': instance.uri,
       'tracks': instance.tracks?.map((e) => e.toJson()).toList(),
@@ -350,64 +335,48 @@ const _$AlbumTypeEnumMap = {
 
 AlbumSimple _$AlbumSimpleFromJson(Map<String, dynamic> json) => AlbumSimple()
   ..albumType = AlbumSimple._convertForAlbumType(json['album_type'] as String?)
-  ..artists = (json['artists'] as List<dynamic>?)
-      ?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
-      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
-      .toList()
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>)).toList()
+  ..availableMarkets =
+      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..name = json['name'] as String?
   ..releaseDate = json['release_date'] as String?
-  ..releaseDatePrecision = $enumDecodeNullable(
-      _$DatePrecisionEnumMap, json['release_date_precision'])
+  ..releaseDatePrecision = $enumDecodeNullable(_$DatePrecisionEnumMap, json['release_date_precision'])
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
   ..tracks = AlbumSimple._extractTracksFromPage(json['tracks']);
 
-Map<String, dynamic> _$AlbumSimpleToJson(AlbumSimple instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$AlbumSimpleToJson(AlbumSimple instance) => <String, dynamic>{
       'album_type': _$AlbumTypeEnumMap[instance.albumType],
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets':
-          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'images': instance.images?.map((e) => e.toJson()).toList(),
       'name': instance.name,
       'release_date': instance.releaseDate,
-      'release_date_precision':
-          _$DatePrecisionEnumMap[instance.releaseDatePrecision],
+      'release_date_precision': _$DatePrecisionEnumMap[instance.releaseDatePrecision],
       'type': instance.type,
       'uri': instance.uri,
       'tracks': instance.tracks?.map((e) => e.toJson()).toList(),
     };
 
 Artist _$ArtistFromJson(Map<String, dynamic> json) => Artist()
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..name = json['name'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
-  ..followers = json['followers'] == null
-      ? null
-      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
-  ..genres =
-      (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..genres = (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..popularity = convertToIntIfDoubleValue(json['popularity']);
 
 Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
@@ -424,17 +393,15 @@ Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
     };
 
 ArtistSimple _$ArtistSimpleFromJson(Map<String, dynamic> json) => ArtistSimple()
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..name = json['name'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) => <String, dynamic>{
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
@@ -443,29 +410,15 @@ Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) =>
       'uri': instance.uri,
     };
 
-AudioAnalysis _$AudioAnalysisFromJson(Map<String, dynamic> json) =>
-    AudioAnalysis()
-      ..track = json['track'] == null
-          ? null
-          : TrackAudioAnalysis.fromJson(json['track'] as Map<String, dynamic>)
-      ..bars = (json['bars'] as List<dynamic>?)
-          ?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..beats = (json['beats'] as List<dynamic>?)
-          ?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..sections = (json['sections'] as List<dynamic>?)
-          ?.map((e) => Section.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..segments = (json['segments'] as List<dynamic>?)
-          ?.map((e) => Segment.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..tatums = (json['tatums'] as List<dynamic>?)
-          ?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>))
-          .toList();
+AudioAnalysis _$AudioAnalysisFromJson(Map<String, dynamic> json) => AudioAnalysis()
+  ..track = json['track'] == null ? null : TrackAudioAnalysis.fromJson(json['track'] as Map<String, dynamic>)
+  ..bars = (json['bars'] as List<dynamic>?)?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>)).toList()
+  ..beats = (json['beats'] as List<dynamic>?)?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>)).toList()
+  ..sections = (json['sections'] as List<dynamic>?)?.map((e) => Section.fromJson(e as Map<String, dynamic>)).toList()
+  ..segments = (json['segments'] as List<dynamic>?)?.map((e) => Segment.fromJson(e as Map<String, dynamic>)).toList()
+  ..tatums = (json['tatums'] as List<dynamic>?)?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>)).toList();
 
-Map<String, dynamic> _$AudioAnalysisToJson(AudioAnalysis instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$AudioAnalysisToJson(AudioAnalysis instance) => <String, dynamic>{
       'track': instance.track?.toJson(),
       'bars': instance.bars?.map((e) => e.toJson()).toList(),
       'beats': instance.beats?.map((e) => e.toJson()).toList(),
@@ -474,35 +427,31 @@ Map<String, dynamic> _$AudioAnalysisToJson(AudioAnalysis instance) =>
       'tatums': instance.tatums?.map((e) => e.toJson()).toList(),
     };
 
-TrackAudioAnalysis _$TrackAudioAnalysisFromJson(Map<String, dynamic> json) =>
-    TrackAudioAnalysis()
-      ..duration = (json['duration'] as num?)?.toDouble()
-      ..confidence = (json['confidence'] as num?)?.toDouble()
-      ..loudness = (json['loudness'] as num?)?.toDouble()
-      ..tempo = (json['tempo'] as num?)?.toDouble()
-      ..tempoConfidence = (json['tempo_confidence'] as num?)?.toDouble()
-      ..key = convertToIntIfDoubleValue(json['key'])
-      ..keyConfidence = (json['key_confidence'] as num?)?.toDouble()
-      ..mode = convertToIntIfDoubleValue(json['mode'])
-      ..modeConfidence = (json['mode_confidence'] as num?)?.toDouble()
-      ..timeSignature = convertToIntIfDoubleValue(json['time_signature'])
-      ..timeSignatureConfidence =
-          (json['time_signature_confidence'] as num?)?.toDouble()
-      ..numSamples = convertToIntIfDoubleValue(json['num_samples'])
-      ..analysisSampleRate =
-          convertToIntIfDoubleValue(json['analysis_sample_rate'])
-      ..analysisChannels = convertToIntIfDoubleValue(json['analysis_channels'])
-      ..endOfFadeIn = (json['end_of_fade_in'] as num?)?.toDouble()
-      ..startOfFadeOut = (json['start_of_fade_out'] as num?)?.toDouble()
-      ..synchString = json['synchstring'] as String?
-      ..synchVersion = (json['synch_version'] as num?)?.toDouble()
-      ..rhythmString = json['rhythmstring'] as String?
-      ..rhythmVersion = (json['rhythm_version'] as num?)?.toDouble()
-      ..codeString = json['codestring'] as String?
-      ..codeVersion = (json['code_version'] as num?)?.toDouble();
+TrackAudioAnalysis _$TrackAudioAnalysisFromJson(Map<String, dynamic> json) => TrackAudioAnalysis()
+  ..duration = (json['duration'] as num?)?.toDouble()
+  ..confidence = (json['confidence'] as num?)?.toDouble()
+  ..loudness = (json['loudness'] as num?)?.toDouble()
+  ..tempo = (json['tempo'] as num?)?.toDouble()
+  ..tempoConfidence = (json['tempo_confidence'] as num?)?.toDouble()
+  ..key = convertToIntIfDoubleValue(json['key'])
+  ..keyConfidence = (json['key_confidence'] as num?)?.toDouble()
+  ..mode = convertToIntIfDoubleValue(json['mode'])
+  ..modeConfidence = (json['mode_confidence'] as num?)?.toDouble()
+  ..timeSignature = convertToIntIfDoubleValue(json['time_signature'])
+  ..timeSignatureConfidence = (json['time_signature_confidence'] as num?)?.toDouble()
+  ..numSamples = convertToIntIfDoubleValue(json['num_samples'])
+  ..analysisSampleRate = convertToIntIfDoubleValue(json['analysis_sample_rate'])
+  ..analysisChannels = convertToIntIfDoubleValue(json['analysis_channels'])
+  ..endOfFadeIn = (json['end_of_fade_in'] as num?)?.toDouble()
+  ..startOfFadeOut = (json['start_of_fade_out'] as num?)?.toDouble()
+  ..synchString = json['synchstring'] as String?
+  ..synchVersion = (json['synch_version'] as num?)?.toDouble()
+  ..rhythmString = json['rhythmstring'] as String?
+  ..rhythmVersion = (json['rhythm_version'] as num?)?.toDouble()
+  ..codeString = json['codestring'] as String?
+  ..codeVersion = (json['code_version'] as num?)?.toDouble();
 
-Map<String, dynamic> _$TrackAudioAnalysisToJson(TrackAudioAnalysis instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$TrackAudioAnalysisToJson(TrackAudioAnalysis instance) => <String, dynamic>{
       'duration': instance.duration,
       'confidence': instance.confidence,
       'loudness': instance.loudness,
@@ -538,8 +487,7 @@ Section _$SectionFromJson(Map<String, dynamic> json) => Section()
   ..mode = convertToIntIfDoubleValue(json['mode'])
   ..modeConfidence = (json['mode_confidence'] as num?)?.toDouble()
   ..timeSignature = convertToIntIfDoubleValue(json['time_signature'])
-  ..timeSignatureConfidence =
-      (json['time_signature_confidence'] as num?)?.toDouble()
+  ..timeSignatureConfidence = (json['time_signature_confidence'] as num?)?.toDouble()
   ..start = (json['start'] as num?)?.toDouble();
 
 Map<String, dynamic> _$SectionToJson(Section instance) => <String, dynamic>{
@@ -565,12 +513,8 @@ Segment _$SegmentFromJson(Map<String, dynamic> json) => Segment()
   ..loudnessMax = (json['loudness_max'] as num?)?.toDouble()
   ..loudnessMaxTime = (json['loudness_max_time'] as num?)?.toDouble()
   ..loudnessEnd = (json['loudness_end'] as num?)?.toDouble()
-  ..pitches = (json['pitches'] as List<dynamic>?)
-      ?.map((e) => (e as num).toDouble())
-      .toList()
-  ..timbre = (json['timbre'] as List<dynamic>?)
-      ?.map((e) => (e as num).toDouble())
-      .toList();
+  ..pitches = (json['pitches'] as List<dynamic>?)?.map((e) => (e as num).toDouble()).toList()
+  ..timbre = (json['timbre'] as List<dynamic>?)?.map((e) => (e as num).toDouble()).toList();
 
 Map<String, dynamic> _$SegmentToJson(Segment instance) => <String, dynamic>{
       'start': instance.start,
@@ -589,8 +533,7 @@ TimeInterval _$TimeIntervalFromJson(Map<String, dynamic> json) => TimeInterval()
   ..duration = (json['duration'] as num?)?.toDouble()
   ..start = (json['start'] as num?)?.toDouble();
 
-Map<String, dynamic> _$TimeIntervalToJson(TimeInterval instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$TimeIntervalToJson(TimeInterval instance) => <String, dynamic>{
       'confidence': instance.confidence,
       'duration': instance.duration,
       'start': instance.start,
@@ -616,8 +559,7 @@ AudioFeature _$AudioFeatureFromJson(Map<String, dynamic> json) => AudioFeature()
   ..uri = json['uri'] as String?
   ..valence = (json['valence'] as num?)?.toDouble();
 
-Map<String, dynamic> _$AudioFeatureToJson(AudioFeature instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$AudioFeatureToJson(AudioFeature instance) => <String, dynamic>{
       'acousticness': instance.acousticness,
       'analysis_url': instance.analysisUrl,
       'danceability': instance.danceability,
@@ -640,9 +582,7 @@ Map<String, dynamic> _$AudioFeatureToJson(AudioFeature instance) =>
 
 Category _$CategoryFromJson(Map<String, dynamic> json) => Category()
   ..href = json['href'] as String?
-  ..icons = (json['icons'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..icons = (json['icons'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..id = json['id'] as String?
   ..name = json['name'] as String?;
 
@@ -673,8 +613,7 @@ Device _$DeviceFromJson(Map<String, dynamic> json) => Device()
   ..isPrivateSession = json['is_private_session'] as bool? ?? false
   ..isRestricted = json['is_restricted'] as bool? ?? false
   ..name = json['name'] as String?
-  ..type = $enumDecodeNullable(_$DeviceTypeEnumMap, json['type'],
-      unknownValue: DeviceType.Unknown)
+  ..type = $enumDecodeNullable(_$DeviceTypeEnumMap, json['type'], unknownValue: DeviceType.Unknown)
   ..volumePercent = convertToIntIfDoubleValue(json['volume_percent']);
 
 Map<String, dynamic> _$DeviceToJson(Device instance) => <String, dynamic>{
@@ -707,8 +646,7 @@ SpotifyError _$SpotifyErrorFromJson(Map<String, dynamic> json) => SpotifyError()
   ..status = convertToIntIfDoubleValue(json['status'])
   ..message = json['message'] as String?;
 
-Map<String, dynamic> _$SpotifyErrorToJson(SpotifyError instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$SpotifyErrorToJson(SpotifyError instance) => <String, dynamic>{
       'status': instance.status,
       'message': instance.message,
     };
@@ -752,18 +690,14 @@ Map<String, dynamic> _$PagingToJson<T>(Paging<T> instance) => <String, dynamic>{
       'total': instance.total,
     };
 
-CursorPaging<T> _$CursorPagingFromJson<T>(Map<String, dynamic> json) =>
-    CursorPaging<T>()
-      ..href = json['href'] as String?
-      ..itemsNative = itemsNativeFromJson(json['items'] as List)
-      ..limit = convertToIntIfDoubleValueWithoutNull(json['limit'])
-      ..next = json['next'] as String?
-      ..cursors = json['cursors'] == null
-          ? null
-          : Cursor.fromJson(json['cursors'] as Map<String, dynamic>);
+CursorPaging<T> _$CursorPagingFromJson<T>(Map<String, dynamic> json) => CursorPaging<T>()
+  ..href = json['href'] as String?
+  ..itemsNative = itemsNativeFromJson(json['items'] as List)
+  ..limit = convertToIntIfDoubleValueWithoutNull(json['limit'])
+  ..next = json['next'] as String?
+  ..cursors = json['cursors'] == null ? null : Cursor.fromJson(json['cursors'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) => <String, dynamic>{
       'href': instance.href,
       'items': itemsNativeToJson(instance.itemsNative),
       'limit': instance.limit,
@@ -771,42 +705,29 @@ Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) =>
       'cursors': instance.cursors?.toJson(),
     };
 
-Cursor _$CursorFromJson(Map<String, dynamic> json) =>
-    Cursor()..after = json['after'] as String?;
+Cursor _$CursorFromJson(Map<String, dynamic> json) => Cursor()..after = json['after'] as String?;
 
 Map<String, dynamic> _$CursorToJson(Cursor instance) => <String, dynamic>{
       'after': instance.after,
     };
 
-PlaybackState _$PlaybackStateFromJson(Map<String, dynamic> json) =>
-    PlaybackState()
-      ..timestamp = convertToIntIfDoubleValue(json['timestamp'])
-      ..context = json['context'] == null
-          ? null
-          : PlayerContext.fromJson(json['context'] as Map<String, dynamic>)
-      ..progressMs = convertToIntIfDoubleValue(json['progress_ms'])
-      ..item = json['item'] == null
-          ? null
-          : Track.fromJson(json['item'] as Map<String, dynamic>)
-      ..currentlyPlayingType = $enumDecodeNullable(
-          _$CurrentlyPlayingTypeEnumMap, json['currently_playing_type'])
-      ..actions = json['actions'] == null
-          ? null
-          : Actions.fromJson(json['actions'] as Map<String, dynamic>)
-      ..isPlaying = json['is_playing'] as bool? ?? false
-      ..isShuffling = json['shuffle_state'] as bool? ?? false
-      ..repeatState =
-          $enumDecodeNullable(_$RepeatStateEnumMap, json['repeat_state']) ??
-              RepeatState.off;
+PlaybackState _$PlaybackStateFromJson(Map<String, dynamic> json) => PlaybackState()
+  ..timestamp = convertToIntIfDoubleValue(json['timestamp'])
+  ..context = json['context'] == null ? null : PlayerContext.fromJson(json['context'] as Map<String, dynamic>)
+  ..progressMs = convertToIntIfDoubleValue(json['progress_ms'])
+  ..item = json['item'] == null ? null : Track.fromJson(json['item'] as Map<String, dynamic>)
+  ..currentlyPlayingType = $enumDecodeNullable(_$CurrentlyPlayingTypeEnumMap, json['currently_playing_type'])
+  ..actions = json['actions'] == null ? null : Actions.fromJson(json['actions'] as Map<String, dynamic>)
+  ..isPlaying = json['is_playing'] as bool? ?? false
+  ..isShuffling = json['shuffle_state'] as bool? ?? false
+  ..repeatState = $enumDecodeNullable(_$RepeatStateEnumMap, json['repeat_state']) ?? RepeatState.off;
 
-Map<String, dynamic> _$PlaybackStateToJson(PlaybackState instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PlaybackStateToJson(PlaybackState instance) => <String, dynamic>{
       'timestamp': instance.timestamp,
       'context': instance.context?.toJson(),
       'progress_ms': instance.progressMs,
       'item': instance.item?.toJson(),
-      'currently_playing_type':
-          _$CurrentlyPlayingTypeEnumMap[instance.currentlyPlayingType],
+      'currently_playing_type': _$CurrentlyPlayingTypeEnumMap[instance.currentlyPlayingType],
       'actions': instance.actions?.toJson(),
       'is_playing': instance.isPlaying,
       'shuffle_state': instance.isShuffling,
@@ -826,17 +747,14 @@ const _$RepeatStateEnumMap = {
   RepeatState.track: 'track',
 };
 
-PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) =>
-    PlayerContext()
-      ..externalUrls = json['external_urls'] == null
-          ? null
-          : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
-      ..href = json['href'] as String?
-      ..type = json['type'] as String?
-      ..uri = json['uri'] as String?;
+PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) => PlayerContext()
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..href = json['href'] as String?
+  ..type = json['type'] as String?
+  ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$PlayerContextToJson(PlayerContext instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PlayerContextToJson(PlayerContext instance) => <String, dynamic>{
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'type': instance.type,
@@ -868,16 +786,12 @@ Map<String, dynamic> _$ActionsToJson(Actions instance) => <String, dynamic>{
       'transferring_playback': instance.transferringPlayback,
     };
 
-Map<String, dynamic> _$StartWithContextOptionsToJson(
-        StartWithContextOptions instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$StartWithContextOptionsToJson(StartWithContextOptions instance) => <String, dynamic>{
       'context_uri': instance.contextUri,
       'offset': StartWithContextOptions._offsetToJson(instance.offset),
     };
 
-Map<String, dynamic> _$StartWithUrisOptionsToJson(
-        StartWithUrisOptions instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$StartWithUrisOptionsToJson(StartWithUrisOptions instance) => <String, dynamic>{
       'uris': instance.uris,
       'position_ms': instance.positionMs,
     };
@@ -886,40 +800,28 @@ Map<String, dynamic> _$UriOffsetToJson(UriOffset instance) => <String, dynamic>{
       'uri': instance.uri,
     };
 
-Map<String, dynamic> _$PositionOffsetToJson(PositionOffset instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PositionOffsetToJson(PositionOffset instance) => <String, dynamic>{
       'position': instance.position,
     };
 
-PlaylistSimple _$PlaylistSimpleFromJson(Map<String, dynamic> json) =>
-    PlaylistSimple()
-      ..href = json['href'] as String?
-      ..id = json['id'] as String?
-      ..uri = json['uri'] as String?
-      ..type = $enumDecodeNullable(_$SpotifyContentTypeEnumMap, json['type'])
-      ..collaborative = json['collaborative'] as bool?
-      ..description = json['description'] as String?
-      ..externalUrls = json['external_urls'] == null
-          ? null
-          : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
-      ..followers = json['followers'] == null
-          ? null
-          : Followers.fromJson(json['followers'] as Map<String, dynamic>)
-      ..images = (json['images'] as List<dynamic>?)
-          ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..name = json['name'] as String?
-      ..owner = json['owner'] == null
-          ? null
-          : User.fromJson(json['owner'] as Map<String, dynamic>)
-      ..public = json['public'] as bool?
-      ..snapshotId = json['snapshot_id'] as String?
-      ..tracks = json['tracks'] == null
-          ? null
-          : TracksLink.fromJson(json['tracks'] as Map<String, dynamic>);
+PlaylistSimple _$PlaylistSimpleFromJson(Map<String, dynamic> json) => PlaylistSimple()
+  ..href = json['href'] as String?
+  ..id = json['id'] as String?
+  ..uri = json['uri'] as String?
+  ..type = $enumDecodeNullable(_$SpotifyContentTypeEnumMap, json['type'])
+  ..collaborative = json['collaborative'] as bool?
+  ..description = json['description'] as String?
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..name = json['name'] as String?
+  ..owner = json['owner'] == null ? null : User.fromJson(json['owner'] as Map<String, dynamic>)
+  ..public = json['public'] as bool?
+  ..snapshotId = json['snapshot_id'] as String?
+  ..tracks = json['tracks'] == null ? null : TracksLink.fromJson(json['tracks'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PlaylistSimpleToJson(PlaylistSimple instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PlaylistSimpleToJson(PlaylistSimple instance) => <String, dynamic>{
       'href': instance.href,
       'id': instance.id,
       'uri': instance.uri,
@@ -951,24 +853,15 @@ Playlist _$PlaylistFromJson(Map<String, dynamic> json) => Playlist()
   ..type = $enumDecodeNullable(_$SpotifyContentTypeEnumMap, json['type'])
   ..collaborative = json['collaborative'] as bool?
   ..description = json['description'] as String?
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
-  ..followers = json['followers'] == null
-      ? null
-      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..name = json['name'] as String?
-  ..owner = json['owner'] == null
-      ? null
-      : User.fromJson(json['owner'] as Map<String, dynamic>)
+  ..owner = json['owner'] == null ? null : User.fromJson(json['owner'] as Map<String, dynamic>)
   ..public = json['public'] as bool?
   ..snapshotId = json['snapshot_id'] as String?
-  ..tracks = json['tracks'] == null
-      ? null
-      : Paging<Track>.fromJson(json['tracks'] as Map<String, dynamic>);
+  ..tracks = json['tracks'] == null ? null : Paging<Track>.fromJson(json['tracks'] as Map<String, dynamic>);
 
 Map<String, dynamic> _$PlaylistToJson(Playlist instance) => <String, dynamic>{
       'href': instance.href,
@@ -987,69 +880,47 @@ Map<String, dynamic> _$PlaylistToJson(Playlist instance) => <String, dynamic>{
       'tracks': instance.tracks?.toJson(),
     };
 
-PlaylistsFeatured _$PlaylistsFeaturedFromJson(Map<String, dynamic> json) =>
-    PlaylistsFeatured()
-      ..content = json['content'] == null
-          ? null
-          : Playlist.fromJson(json['content'] as Map<String, dynamic>)
-      ..message = json['message'] as String?;
+PlaylistsFeatured _$PlaylistsFeaturedFromJson(Map<String, dynamic> json) => PlaylistsFeatured()
+  ..content = json['content'] == null ? null : Playlist.fromJson(json['content'] as Map<String, dynamic>)
+  ..message = json['message'] as String?;
 
-Map<String, dynamic> _$PlaylistsFeaturedToJson(PlaylistsFeatured instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PlaylistsFeaturedToJson(PlaylistsFeatured instance) => <String, dynamic>{
       'content': instance.content?.toJson(),
       'message': instance.message,
     };
 
-PlaylistTrack _$PlaylistTrackFromJson(Map<String, dynamic> json) =>
-    PlaylistTrack()
-      ..addedAt = json['added_at'] == null
-          ? null
-          : DateTime.parse(json['added_at'] as String)
-      ..addedBy = json['added_by'] == null
-          ? null
-          : UserPublic.fromJson(json['added_by'] as Map<String, dynamic>)
-      ..isLocal = json['is_local'] as bool?
-      ..track = json['track'] == null
-          ? null
-          : Track.fromJson(json['track'] as Map<String, dynamic>);
+PlaylistTrack _$PlaylistTrackFromJson(Map<String, dynamic> json) => PlaylistTrack()
+  ..addedAt = json['added_at'] == null ? null : DateTime.parse(json['added_at'] as String)
+  ..addedBy = json['added_by'] == null ? null : UserPublic.fromJson(json['added_by'] as Map<String, dynamic>)
+  ..isLocal = json['is_local'] as bool?
+  ..track = json['track'] == null ? null : Track.fromJson(json['track'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PlaylistTrackToJson(PlaylistTrack instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PlaylistTrackToJson(PlaylistTrack instance) => <String, dynamic>{
       'added_at': instance.addedAt?.toIso8601String(),
       'added_by': instance.addedBy?.toJson(),
       'is_local': instance.isLocal,
       'track': instance.track?.toJson(),
     };
 
-Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) =>
-    Recommendations()
-      ..seeds = (json['seeds'] as List<dynamic>?)
-          ?.map((e) => RecommendationsSeed.fromJson(e as Map<String, dynamic>))
-          .toList()
-      ..tracks = (json['tracks'] as List<dynamic>?)
-          ?.map((e) => Track.fromJson(e as Map<String, dynamic>))
-          .toList();
+Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) => Recommendations()
+  ..seeds =
+      (json['seeds'] as List<dynamic>?)?.map((e) => RecommendationsSeed.fromJson(e as Map<String, dynamic>)).toList()
+  ..tracks = (json['tracks'] as List<dynamic>?)?.map((e) => Track.fromJson(e as Map<String, dynamic>)).toList();
 
-Map<String, dynamic> _$RecommendationsToJson(Recommendations instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$RecommendationsToJson(Recommendations instance) => <String, dynamic>{
       'seeds': instance.seeds?.map((e) => e.toJson()).toList(),
       'tracks': instance.tracks?.map((e) => e.toJson()).toList(),
     };
 
-RecommendationsSeed _$RecommendationsSeedFromJson(Map<String, dynamic> json) =>
-    RecommendationsSeed()
-      ..afterFilteringSize =
-          convertToIntIfDoubleValue(json['afterFilteringSize'])
-      ..afterRelinkingSize =
-          convertToIntIfDoubleValue(json['afterRelinkingSize'])
-      ..href = json['href'] as String?
-      ..id = json['id'] as String?
-      ..initialPoolSize = convertToIntIfDoubleValue(json['initialPoolSize'])
-      ..type = json['type'] as String?;
+RecommendationsSeed _$RecommendationsSeedFromJson(Map<String, dynamic> json) => RecommendationsSeed()
+  ..afterFilteringSize = convertToIntIfDoubleValue(json['afterFilteringSize'])
+  ..afterRelinkingSize = convertToIntIfDoubleValue(json['afterRelinkingSize'])
+  ..href = json['href'] as String?
+  ..id = json['id'] as String?
+  ..initialPoolSize = convertToIntIfDoubleValue(json['initialPoolSize'])
+  ..type = json['type'] as String?;
 
-Map<String, dynamic> _$RecommendationsSeedToJson(
-        RecommendationsSeed instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$RecommendationsSeedToJson(RecommendationsSeed instance) => <String, dynamic>{
       'afterFilteringSize': instance.afterFilteringSize,
       'afterRelinkingSize': instance.afterRelinkingSize,
       'href': instance.href,
@@ -1063,37 +934,28 @@ Show _$ShowFromJson(Map<String, dynamic> json) => Show()
   ..id = json['id'] as String?
   ..uri = json['uri'] as String?
   ..type = $enumDecodeNullable(_$SpotifyContentTypeEnumMap, json['type'])
-  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
-      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
-      .toList()
-  ..copyrights = (json['copyrights'] as List<dynamic>?)
-      ?.map((e) => Copyright.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..availableMarkets =
+      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
+  ..copyrights =
+      (json['copyrights'] as List<dynamic>?)?.map((e) => Copyright.fromJson(e as Map<String, dynamic>)).toList()
   ..description = json['description'] as String?
   ..explicit = json['explicit'] as bool?
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..isExternallyHosted = json['is_externally_hosted'] as bool?
-  ..languages =
-      (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..languages = (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..mediaType = json['media_type'] as String?
   ..name = json['name'] as String?
   ..publisher = json['publisher'] as String?
-  ..totalEpisodes = json['total_episodes'] == null
-      ? 0
-      : convertToIntIfDoubleValue(json['total_episodes']);
+  ..totalEpisodes = json['total_episodes'] == null ? 0 : convertToIntIfDoubleValue(json['total_episodes']);
 
 Map<String, dynamic> _$ShowToJson(Show instance) => <String, dynamic>{
       'href': instance.href,
       'id': instance.id,
       'uri': instance.uri,
       'type': _$SpotifyContentTypeEnumMap[instance.type],
-      'available_markets':
-          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'copyrights': instance.copyrights?.map((e) => e.toJson()).toList(),
       'description': instance.description,
       'explicit': instance.explicit,
@@ -1112,23 +974,17 @@ Episode _$EpisodeFromJson(Map<String, dynamic> json) => Episode()
   ..description = json['description'] as String?
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..isExternallyHosted = json['is_externally_hosted'] as bool?
   ..isPlayable = json['is_playable'] as bool?
   ..language = json['language'] as String?
-  ..languages =
-      (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..languages = (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..name = json['name'] as String?
-  ..releaseDate = json['release_date'] == null
-      ? null
-      : DateTime.parse(json['release_date'] as String)
+  ..releaseDate = json['release_date'] == null ? null : DateTime.parse(json['release_date'] as String)
   ..releaseDatePrecision = json['release_date_precision'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
@@ -1158,32 +1014,23 @@ EpisodeFull _$EpisodeFullFromJson(Map<String, dynamic> json) => EpisodeFull()
   ..description = json['description'] as String?
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..isExternallyHosted = json['is_externally_hosted'] as bool?
   ..isPlayable = json['is_playable'] as bool?
   ..language = json['language'] as String?
-  ..languages =
-      (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..languages = (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..name = json['name'] as String?
-  ..releaseDate = json['release_date'] == null
-      ? null
-      : DateTime.parse(json['release_date'] as String)
+  ..releaseDate = json['release_date'] == null ? null : DateTime.parse(json['release_date'] as String)
   ..releaseDatePrecision = json['release_date_precision'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
-  ..show = json['show'] == null
-      ? null
-      : Show.fromJson(json['show'] as Map<String, dynamic>);
+  ..show = json['show'] == null ? null : Show.fromJson(json['show'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$EpisodeFullToJson(EpisodeFull instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$EpisodeFullToJson(EpisodeFull instance) => <String, dynamic>{
       'audio_preview_url': instance.audioPreviewUrl,
       'description': instance.description,
       'duration_ms': instance.durationMs,
@@ -1205,30 +1052,21 @@ Map<String, dynamic> _$EpisodeFullToJson(EpisodeFull instance) =>
     };
 
 Track _$TrackFromJson(Map<String, dynamic> json) => Track()
-  ..album = json['album'] == null
-      ? null
-      : AlbumSimple.fromJson(json['album'] as Map<String, dynamic>)
-  ..artists = (json['artists'] as List<dynamic>?)
-      ?.map((e) => Artist.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
-      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
-      .toList()
+  ..album = json['album'] == null ? null : AlbumSimple.fromJson(json['album'] as Map<String, dynamic>)
+  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => Artist.fromJson(e as Map<String, dynamic>)).toList()
+  ..availableMarkets =
+      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
   ..discNumber = convertToIntIfDoubleValue(json['disc_number'])
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalIds = json['external_ids'] == null
-      ? null
-      : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalIds =
+      json['external_ids'] == null ? null : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..isPlayable = json['is_playable'] as bool?
-  ..linkedFrom = json['linked_from'] == null
-      ? null
-      : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
+  ..linkedFrom = json['linked_from'] == null ? null : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
   ..name = json['name'] as String?
   ..popularity = convertToIntIfDoubleValue(json['popularity'])
   ..previewUrl = json['preview_url'] as String?
@@ -1239,8 +1077,7 @@ Track _$TrackFromJson(Map<String, dynamic> json) => Track()
 Map<String, dynamic> _$TrackToJson(Track instance) => <String, dynamic>{
       'album': instance.album?.toJson(),
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets':
-          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'disc_number': instance.discNumber,
       'duration_ms': instance.durationMs,
       'explicit': instance.explicit,
@@ -1259,35 +1096,27 @@ Map<String, dynamic> _$TrackToJson(Track instance) => <String, dynamic>{
     };
 
 TrackSimple _$TrackSimpleFromJson(Map<String, dynamic> json) => TrackSimple()
-  ..artists = (json['artists'] as List<dynamic>?)
-      ?.map((e) => Artist.fromJson(e as Map<String, dynamic>))
-      .toList()
-  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
-      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
-      .toList()
+  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => Artist.fromJson(e as Map<String, dynamic>)).toList()
+  ..availableMarkets =
+      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
   ..discNumber = convertToIntIfDoubleValue(json['disc_number'])
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalUrls = json['external_urls'] == null
-      ? null
-      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls =
+      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..isPlayable = json['is_playable'] as bool?
-  ..linkedFrom = json['linked_from'] == null
-      ? null
-      : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
+  ..linkedFrom = json['linked_from'] == null ? null : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
   ..name = json['name'] as String?
   ..previewUrl = json['preview_url'] as String?
   ..trackNumber = convertToIntIfDoubleValue(json['track_number'])
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) => <String, dynamic>{
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets':
-          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'disc_number': instance.discNumber,
       'duration_ms': instance.durationMs,
       'explicit': instance.explicit,
@@ -1304,15 +1133,10 @@ Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) =>
     };
 
 TrackSaved _$TrackSavedFromJson(Map<String, dynamic> json) => TrackSaved()
-  ..addedAt = json['added_at'] == null
-      ? null
-      : DateTime.parse(json['added_at'] as String)
-  ..track = json['track'] == null
-      ? null
-      : Track.fromJson(json['track'] as Map<String, dynamic>);
+  ..addedAt = json['added_at'] == null ? null : DateTime.parse(json['added_at'] as String)
+  ..track = json['track'] == null ? null : Track.fromJson(json['track'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$TrackSavedToJson(TrackSaved instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$TrackSavedToJson(TrackSaved instance) => <String, dynamic>{
       'added_at': instance.addedAt?.toIso8601String(),
       'track': instance.track?.toJson(),
     };
@@ -1338,8 +1162,7 @@ TracksLink _$TracksLinkFromJson(Map<String, dynamic> json) => TracksLink()
   ..href = json['href'] as String?
   ..total = convertToIntIfDoubleValue(json['total']);
 
-Map<String, dynamic> _$TracksLinkToJson(TracksLink instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$TracksLinkToJson(TracksLink instance) => <String, dynamic>{
       'href': instance.href,
       'total': instance.total,
     };
@@ -1349,14 +1172,10 @@ User _$UserFromJson(Map<String, dynamic> json) => User()
   ..country = $enumDecodeNullable(_$MarketEnumMap, json['country'])
   ..displayName = json['display_name'] as String?
   ..email = json['email'] as String?
-  ..followers = json['followers'] == null
-      ? null
-      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..product = json['product'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
@@ -1377,19 +1196,14 @@ Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
 
 UserPublic _$UserPublicFromJson(Map<String, dynamic> json) => UserPublic()
   ..displayName = json['display_name'] as String?
-  ..followers = json['followers'] == null
-      ? null
-      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)
-      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
-      .toList()
+  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$UserPublicToJson(UserPublic instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$UserPublicToJson(UserPublic instance) => <String, dynamic>{
       'display_name': instance.displayName,
       'followers': instance.followers?.toJson(),
       'href': instance.href,
@@ -1400,30 +1214,20 @@ Map<String, dynamic> _$UserPublicToJson(UserPublic instance) =>
     };
 
 PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) => PlayHistory()
-  ..track = json['track'] == null
-      ? null
-      : Track.fromJson(json['track'] as Map<String, dynamic>)
-  ..playedAt = json['played_at'] == null
-      ? null
-      : DateTime.parse(json['played_at'] as String)
-  ..context = json['context'] == null
-      ? null
-      : PlayerContext.fromJson(json['context'] as Map<String, dynamic>);
+  ..track = json['track'] == null ? null : Track.fromJson(json['track'] as Map<String, dynamic>)
+  ..playedAt = json['played_at'] == null ? null : DateTime.parse(json['played_at'] as String)
+  ..context = json['context'] == null ? null : PlayerContext.fromJson(json['context'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PlayHistoryToJson(PlayHistory instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PlayHistoryToJson(PlayHistory instance) => <String, dynamic>{
       'track': instance.track?.toJson(),
       'played_at': instance.playedAt?.toIso8601String(),
       'context': instance.context?.toJson(),
     };
 
 Queue _$QueueFromJson(Map<String, dynamic> json) => Queue()
-  ..currentlyPlaying = json['currently_playing'] == null
-      ? null
-      : Track.fromJson(json['currently_playing'] as Map<String, dynamic>)
-  ..queue = (json['queue'] as List<dynamic>?)
-      ?.map((e) => Track.fromJson(e as Map<String, dynamic>))
-      .toList();
+  ..currentlyPlaying =
+      json['currently_playing'] == null ? null : Track.fromJson(json['currently_playing'] as Map<String, dynamic>)
+  ..queue = (json['queue'] as List<dynamic>?)?.map((e) => Track.fromJson(e as Map<String, dynamic>)).toList();
 
 Map<String, dynamic> _$QueueToJson(Queue instance) => <String, dynamic>{
       'currently_playing': instance.currentlyPlaying?.toJson(),

--- a/lib/src/models/_models.g.dart
+++ b/lib/src/models/_models.g.dart
@@ -6,9 +6,11 @@ part of '_models.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-ExternalUrls _$ExternalUrlsFromJson(Map<String, dynamic> json) => ExternalUrls()..spotify = json['spotify'] as String?;
+ExternalUrls _$ExternalUrlsFromJson(Map<String, dynamic> json) =>
+    ExternalUrls()..spotify = json['spotify'] as String?;
 
-Map<String, dynamic> _$ExternalUrlsToJson(ExternalUrls instance) => <String, dynamic>{
+Map<String, dynamic> _$ExternalUrlsToJson(ExternalUrls instance) =>
+    <String, dynamic>{
       'spotify': instance.spotify,
     };
 
@@ -17,7 +19,8 @@ ExternalIds _$ExternalIdsFromJson(Map<String, dynamic> json) => ExternalIds()
   ..ean = json['ean'] as String?
   ..upc = json['upc'] as String?;
 
-Map<String, dynamic> _$ExternalIdsToJson(ExternalIds instance) => <String, dynamic>{
+Map<String, dynamic> _$ExternalIdsToJson(ExternalIds instance) =>
+    <String, dynamic>{
       'isrc': instance.isrc,
       'ean': instance.ean,
       'upc': instance.upc,
@@ -25,39 +28,51 @@ Map<String, dynamic> _$ExternalIdsToJson(ExternalIds instance) => <String, dynam
 
 Album _$AlbumFromJson(Map<String, dynamic> json) => Album()
   ..albumType = AlbumSimple._convertForAlbumType(json['album_type'] as String?)
-  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>)).toList()
-  ..availableMarkets =
-      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..artists = (json['artists'] as List<dynamic>?)
+      ?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
+      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
+      .toList()
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..name = json['name'] as String?
   ..releaseDate = json['release_date'] as String?
-  ..releaseDatePrecision = $enumDecodeNullable(_$DatePrecisionEnumMap, json['release_date_precision'])
+  ..releaseDatePrecision = $enumDecodeNullable(
+      _$DatePrecisionEnumMap, json['release_date_precision'])
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
   ..tracks = AlbumSimple._extractTracksFromPage(json['tracks'])
-  ..copyrights =
-      (json['copyrights'] as List<dynamic>?)?.map((e) => Copyright.fromJson(e as Map<String, dynamic>)).toList()
-  ..externalIds =
-      json['external_ids'] == null ? null : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
-  ..genres = (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..copyrights = (json['copyrights'] as List<dynamic>?)
+      ?.map((e) => Copyright.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..externalIds = json['external_ids'] == null
+      ? null
+      : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
+  ..genres =
+      (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..label = json['label'] as String?
   ..popularity = convertToIntIfDoubleValue(json['popularity']);
 
 Map<String, dynamic> _$AlbumToJson(Album instance) => <String, dynamic>{
       'album_type': _$AlbumTypeEnumMap[instance.albumType],
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets':
+          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'images': instance.images?.map((e) => e.toJson()).toList(),
       'name': instance.name,
       'release_date': instance.releaseDate,
-      'release_date_precision': _$DatePrecisionEnumMap[instance.releaseDatePrecision],
+      'release_date_precision':
+          _$DatePrecisionEnumMap[instance.releaseDatePrecision],
       'type': instance.type,
       'uri': instance.uri,
       'tracks': instance.tracks?.map((e) => e.toJson()).toList(),
@@ -335,48 +350,64 @@ const _$AlbumTypeEnumMap = {
 
 AlbumSimple _$AlbumSimpleFromJson(Map<String, dynamic> json) => AlbumSimple()
   ..albumType = AlbumSimple._convertForAlbumType(json['album_type'] as String?)
-  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>)).toList()
-  ..availableMarkets =
-      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..artists = (json['artists'] as List<dynamic>?)
+      ?.map((e) => ArtistSimple.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
+      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
+      .toList()
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..name = json['name'] as String?
   ..releaseDate = json['release_date'] as String?
-  ..releaseDatePrecision = $enumDecodeNullable(_$DatePrecisionEnumMap, json['release_date_precision'])
+  ..releaseDatePrecision = $enumDecodeNullable(
+      _$DatePrecisionEnumMap, json['release_date_precision'])
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
   ..tracks = AlbumSimple._extractTracksFromPage(json['tracks']);
 
-Map<String, dynamic> _$AlbumSimpleToJson(AlbumSimple instance) => <String, dynamic>{
+Map<String, dynamic> _$AlbumSimpleToJson(AlbumSimple instance) =>
+    <String, dynamic>{
       'album_type': _$AlbumTypeEnumMap[instance.albumType],
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets':
+          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
       'images': instance.images?.map((e) => e.toJson()).toList(),
       'name': instance.name,
       'release_date': instance.releaseDate,
-      'release_date_precision': _$DatePrecisionEnumMap[instance.releaseDatePrecision],
+      'release_date_precision':
+          _$DatePrecisionEnumMap[instance.releaseDatePrecision],
       'type': instance.type,
       'uri': instance.uri,
       'tracks': instance.tracks?.map((e) => e.toJson()).toList(),
     };
 
 Artist _$ArtistFromJson(Map<String, dynamic> json) => Artist()
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..name = json['name'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
-  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
-  ..genres = (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..followers = json['followers'] == null
+      ? null
+      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..genres =
+      (json['genres'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..popularity = convertToIntIfDoubleValue(json['popularity']);
 
 Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
@@ -393,15 +424,17 @@ Map<String, dynamic> _$ArtistToJson(Artist instance) => <String, dynamic>{
     };
 
 ArtistSimple _$ArtistSimpleFromJson(Map<String, dynamic> json) => ArtistSimple()
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..name = json['name'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) => <String, dynamic>{
+Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) =>
+    <String, dynamic>{
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'id': instance.id,
@@ -410,15 +443,29 @@ Map<String, dynamic> _$ArtistSimpleToJson(ArtistSimple instance) => <String, dyn
       'uri': instance.uri,
     };
 
-AudioAnalysis _$AudioAnalysisFromJson(Map<String, dynamic> json) => AudioAnalysis()
-  ..track = json['track'] == null ? null : TrackAudioAnalysis.fromJson(json['track'] as Map<String, dynamic>)
-  ..bars = (json['bars'] as List<dynamic>?)?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>)).toList()
-  ..beats = (json['beats'] as List<dynamic>?)?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>)).toList()
-  ..sections = (json['sections'] as List<dynamic>?)?.map((e) => Section.fromJson(e as Map<String, dynamic>)).toList()
-  ..segments = (json['segments'] as List<dynamic>?)?.map((e) => Segment.fromJson(e as Map<String, dynamic>)).toList()
-  ..tatums = (json['tatums'] as List<dynamic>?)?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>)).toList();
+AudioAnalysis _$AudioAnalysisFromJson(Map<String, dynamic> json) =>
+    AudioAnalysis()
+      ..track = json['track'] == null
+          ? null
+          : TrackAudioAnalysis.fromJson(json['track'] as Map<String, dynamic>)
+      ..bars = (json['bars'] as List<dynamic>?)
+          ?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..beats = (json['beats'] as List<dynamic>?)
+          ?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..sections = (json['sections'] as List<dynamic>?)
+          ?.map((e) => Section.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..segments = (json['segments'] as List<dynamic>?)
+          ?.map((e) => Segment.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..tatums = (json['tatums'] as List<dynamic>?)
+          ?.map((e) => TimeInterval.fromJson(e as Map<String, dynamic>))
+          .toList();
 
-Map<String, dynamic> _$AudioAnalysisToJson(AudioAnalysis instance) => <String, dynamic>{
+Map<String, dynamic> _$AudioAnalysisToJson(AudioAnalysis instance) =>
+    <String, dynamic>{
       'track': instance.track?.toJson(),
       'bars': instance.bars?.map((e) => e.toJson()).toList(),
       'beats': instance.beats?.map((e) => e.toJson()).toList(),
@@ -427,31 +474,35 @@ Map<String, dynamic> _$AudioAnalysisToJson(AudioAnalysis instance) => <String, d
       'tatums': instance.tatums?.map((e) => e.toJson()).toList(),
     };
 
-TrackAudioAnalysis _$TrackAudioAnalysisFromJson(Map<String, dynamic> json) => TrackAudioAnalysis()
-  ..duration = (json['duration'] as num?)?.toDouble()
-  ..confidence = (json['confidence'] as num?)?.toDouble()
-  ..loudness = (json['loudness'] as num?)?.toDouble()
-  ..tempo = (json['tempo'] as num?)?.toDouble()
-  ..tempoConfidence = (json['tempo_confidence'] as num?)?.toDouble()
-  ..key = convertToIntIfDoubleValue(json['key'])
-  ..keyConfidence = (json['key_confidence'] as num?)?.toDouble()
-  ..mode = convertToIntIfDoubleValue(json['mode'])
-  ..modeConfidence = (json['mode_confidence'] as num?)?.toDouble()
-  ..timeSignature = convertToIntIfDoubleValue(json['time_signature'])
-  ..timeSignatureConfidence = (json['time_signature_confidence'] as num?)?.toDouble()
-  ..numSamples = convertToIntIfDoubleValue(json['num_samples'])
-  ..analysisSampleRate = convertToIntIfDoubleValue(json['analysis_sample_rate'])
-  ..analysisChannels = convertToIntIfDoubleValue(json['analysis_channels'])
-  ..endOfFadeIn = (json['end_of_fade_in'] as num?)?.toDouble()
-  ..startOfFadeOut = (json['start_of_fade_out'] as num?)?.toDouble()
-  ..synchString = json['synchstring'] as String?
-  ..synchVersion = (json['synch_version'] as num?)?.toDouble()
-  ..rhythmString = json['rhythmstring'] as String?
-  ..rhythmVersion = (json['rhythm_version'] as num?)?.toDouble()
-  ..codeString = json['codestring'] as String?
-  ..codeVersion = (json['code_version'] as num?)?.toDouble();
+TrackAudioAnalysis _$TrackAudioAnalysisFromJson(Map<String, dynamic> json) =>
+    TrackAudioAnalysis()
+      ..duration = (json['duration'] as num?)?.toDouble()
+      ..confidence = (json['confidence'] as num?)?.toDouble()
+      ..loudness = (json['loudness'] as num?)?.toDouble()
+      ..tempo = (json['tempo'] as num?)?.toDouble()
+      ..tempoConfidence = (json['tempo_confidence'] as num?)?.toDouble()
+      ..key = convertToIntIfDoubleValue(json['key'])
+      ..keyConfidence = (json['key_confidence'] as num?)?.toDouble()
+      ..mode = convertToIntIfDoubleValue(json['mode'])
+      ..modeConfidence = (json['mode_confidence'] as num?)?.toDouble()
+      ..timeSignature = convertToIntIfDoubleValue(json['time_signature'])
+      ..timeSignatureConfidence =
+          (json['time_signature_confidence'] as num?)?.toDouble()
+      ..numSamples = convertToIntIfDoubleValue(json['num_samples'])
+      ..analysisSampleRate =
+          convertToIntIfDoubleValue(json['analysis_sample_rate'])
+      ..analysisChannels = convertToIntIfDoubleValue(json['analysis_channels'])
+      ..endOfFadeIn = (json['end_of_fade_in'] as num?)?.toDouble()
+      ..startOfFadeOut = (json['start_of_fade_out'] as num?)?.toDouble()
+      ..synchString = json['synchstring'] as String?
+      ..synchVersion = (json['synch_version'] as num?)?.toDouble()
+      ..rhythmString = json['rhythmstring'] as String?
+      ..rhythmVersion = (json['rhythm_version'] as num?)?.toDouble()
+      ..codeString = json['codestring'] as String?
+      ..codeVersion = (json['code_version'] as num?)?.toDouble();
 
-Map<String, dynamic> _$TrackAudioAnalysisToJson(TrackAudioAnalysis instance) => <String, dynamic>{
+Map<String, dynamic> _$TrackAudioAnalysisToJson(TrackAudioAnalysis instance) =>
+    <String, dynamic>{
       'duration': instance.duration,
       'confidence': instance.confidence,
       'loudness': instance.loudness,
@@ -487,7 +538,8 @@ Section _$SectionFromJson(Map<String, dynamic> json) => Section()
   ..mode = convertToIntIfDoubleValue(json['mode'])
   ..modeConfidence = (json['mode_confidence'] as num?)?.toDouble()
   ..timeSignature = convertToIntIfDoubleValue(json['time_signature'])
-  ..timeSignatureConfidence = (json['time_signature_confidence'] as num?)?.toDouble()
+  ..timeSignatureConfidence =
+      (json['time_signature_confidence'] as num?)?.toDouble()
   ..start = (json['start'] as num?)?.toDouble();
 
 Map<String, dynamic> _$SectionToJson(Section instance) => <String, dynamic>{
@@ -513,8 +565,12 @@ Segment _$SegmentFromJson(Map<String, dynamic> json) => Segment()
   ..loudnessMax = (json['loudness_max'] as num?)?.toDouble()
   ..loudnessMaxTime = (json['loudness_max_time'] as num?)?.toDouble()
   ..loudnessEnd = (json['loudness_end'] as num?)?.toDouble()
-  ..pitches = (json['pitches'] as List<dynamic>?)?.map((e) => (e as num).toDouble()).toList()
-  ..timbre = (json['timbre'] as List<dynamic>?)?.map((e) => (e as num).toDouble()).toList();
+  ..pitches = (json['pitches'] as List<dynamic>?)
+      ?.map((e) => (e as num).toDouble())
+      .toList()
+  ..timbre = (json['timbre'] as List<dynamic>?)
+      ?.map((e) => (e as num).toDouble())
+      .toList();
 
 Map<String, dynamic> _$SegmentToJson(Segment instance) => <String, dynamic>{
       'start': instance.start,
@@ -533,7 +589,8 @@ TimeInterval _$TimeIntervalFromJson(Map<String, dynamic> json) => TimeInterval()
   ..duration = (json['duration'] as num?)?.toDouble()
   ..start = (json['start'] as num?)?.toDouble();
 
-Map<String, dynamic> _$TimeIntervalToJson(TimeInterval instance) => <String, dynamic>{
+Map<String, dynamic> _$TimeIntervalToJson(TimeInterval instance) =>
+    <String, dynamic>{
       'confidence': instance.confidence,
       'duration': instance.duration,
       'start': instance.start,
@@ -559,7 +616,8 @@ AudioFeature _$AudioFeatureFromJson(Map<String, dynamic> json) => AudioFeature()
   ..uri = json['uri'] as String?
   ..valence = (json['valence'] as num?)?.toDouble();
 
-Map<String, dynamic> _$AudioFeatureToJson(AudioFeature instance) => <String, dynamic>{
+Map<String, dynamic> _$AudioFeatureToJson(AudioFeature instance) =>
+    <String, dynamic>{
       'acousticness': instance.acousticness,
       'analysis_url': instance.analysisUrl,
       'danceability': instance.danceability,
@@ -582,7 +640,9 @@ Map<String, dynamic> _$AudioFeatureToJson(AudioFeature instance) => <String, dyn
 
 Category _$CategoryFromJson(Map<String, dynamic> json) => Category()
   ..href = json['href'] as String?
-  ..icons = (json['icons'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..icons = (json['icons'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..id = json['id'] as String?
   ..name = json['name'] as String?;
 
@@ -613,7 +673,8 @@ Device _$DeviceFromJson(Map<String, dynamic> json) => Device()
   ..isPrivateSession = json['is_private_session'] as bool? ?? false
   ..isRestricted = json['is_restricted'] as bool? ?? false
   ..name = json['name'] as String?
-  ..type = $enumDecodeNullable(_$DeviceTypeEnumMap, json['type'], unknownValue: DeviceType.Unknown)
+  ..type = $enumDecodeNullable(_$DeviceTypeEnumMap, json['type'],
+      unknownValue: DeviceType.Unknown)
   ..volumePercent = convertToIntIfDoubleValue(json['volume_percent']);
 
 Map<String, dynamic> _$DeviceToJson(Device instance) => <String, dynamic>{
@@ -646,7 +707,8 @@ SpotifyError _$SpotifyErrorFromJson(Map<String, dynamic> json) => SpotifyError()
   ..status = convertToIntIfDoubleValue(json['status'])
   ..message = json['message'] as String?;
 
-Map<String, dynamic> _$SpotifyErrorToJson(SpotifyError instance) => <String, dynamic>{
+Map<String, dynamic> _$SpotifyErrorToJson(SpotifyError instance) =>
+    <String, dynamic>{
       'status': instance.status,
       'message': instance.message,
     };
@@ -690,14 +752,18 @@ Map<String, dynamic> _$PagingToJson<T>(Paging<T> instance) => <String, dynamic>{
       'total': instance.total,
     };
 
-CursorPaging<T> _$CursorPagingFromJson<T>(Map<String, dynamic> json) => CursorPaging<T>()
-  ..href = json['href'] as String?
-  ..itemsNative = itemsNativeFromJson(json['items'] as List)
-  ..limit = convertToIntIfDoubleValueWithoutNull(json['limit'])
-  ..next = json['next'] as String?
-  ..cursors = json['cursors'] == null ? null : Cursor.fromJson(json['cursors'] as Map<String, dynamic>);
+CursorPaging<T> _$CursorPagingFromJson<T>(Map<String, dynamic> json) =>
+    CursorPaging<T>()
+      ..href = json['href'] as String?
+      ..itemsNative = itemsNativeFromJson(json['items'] as List)
+      ..limit = convertToIntIfDoubleValueWithoutNull(json['limit'])
+      ..next = json['next'] as String?
+      ..cursors = json['cursors'] == null
+          ? null
+          : Cursor.fromJson(json['cursors'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) => <String, dynamic>{
+Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) =>
+    <String, dynamic>{
       'href': instance.href,
       'items': itemsNativeToJson(instance.itemsNative),
       'limit': instance.limit,
@@ -705,29 +771,42 @@ Map<String, dynamic> _$CursorPagingToJson<T>(CursorPaging<T> instance) => <Strin
       'cursors': instance.cursors?.toJson(),
     };
 
-Cursor _$CursorFromJson(Map<String, dynamic> json) => Cursor()..after = json['after'] as String?;
+Cursor _$CursorFromJson(Map<String, dynamic> json) =>
+    Cursor()..after = json['after'] as String?;
 
 Map<String, dynamic> _$CursorToJson(Cursor instance) => <String, dynamic>{
       'after': instance.after,
     };
 
-PlaybackState _$PlaybackStateFromJson(Map<String, dynamic> json) => PlaybackState()
-  ..timestamp = convertToIntIfDoubleValue(json['timestamp'])
-  ..context = json['context'] == null ? null : PlayerContext.fromJson(json['context'] as Map<String, dynamic>)
-  ..progressMs = convertToIntIfDoubleValue(json['progress_ms'])
-  ..item = json['item'] == null ? null : Track.fromJson(json['item'] as Map<String, dynamic>)
-  ..currentlyPlayingType = $enumDecodeNullable(_$CurrentlyPlayingTypeEnumMap, json['currently_playing_type'])
-  ..actions = json['actions'] == null ? null : Actions.fromJson(json['actions'] as Map<String, dynamic>)
-  ..isPlaying = json['is_playing'] as bool? ?? false
-  ..isShuffling = json['shuffle_state'] as bool? ?? false
-  ..repeatState = $enumDecodeNullable(_$RepeatStateEnumMap, json['repeat_state']) ?? RepeatState.off;
+PlaybackState _$PlaybackStateFromJson(Map<String, dynamic> json) =>
+    PlaybackState()
+      ..timestamp = convertToIntIfDoubleValue(json['timestamp'])
+      ..context = json['context'] == null
+          ? null
+          : PlayerContext.fromJson(json['context'] as Map<String, dynamic>)
+      ..progressMs = convertToIntIfDoubleValue(json['progress_ms'])
+      ..item = json['item'] == null
+          ? null
+          : Track.fromJson(json['item'] as Map<String, dynamic>)
+      ..currentlyPlayingType = $enumDecodeNullable(
+          _$CurrentlyPlayingTypeEnumMap, json['currently_playing_type'])
+      ..actions = json['actions'] == null
+          ? null
+          : Actions.fromJson(json['actions'] as Map<String, dynamic>)
+      ..isPlaying = json['is_playing'] as bool? ?? false
+      ..isShuffling = json['shuffle_state'] as bool? ?? false
+      ..repeatState =
+          $enumDecodeNullable(_$RepeatStateEnumMap, json['repeat_state']) ??
+              RepeatState.off;
 
-Map<String, dynamic> _$PlaybackStateToJson(PlaybackState instance) => <String, dynamic>{
+Map<String, dynamic> _$PlaybackStateToJson(PlaybackState instance) =>
+    <String, dynamic>{
       'timestamp': instance.timestamp,
       'context': instance.context?.toJson(),
       'progress_ms': instance.progressMs,
       'item': instance.item?.toJson(),
-      'currently_playing_type': _$CurrentlyPlayingTypeEnumMap[instance.currentlyPlayingType],
+      'currently_playing_type':
+          _$CurrentlyPlayingTypeEnumMap[instance.currentlyPlayingType],
       'actions': instance.actions?.toJson(),
       'is_playing': instance.isPlaying,
       'shuffle_state': instance.isShuffling,
@@ -747,14 +826,17 @@ const _$RepeatStateEnumMap = {
   RepeatState.track: 'track',
 };
 
-PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) => PlayerContext()
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
-  ..href = json['href'] as String?
-  ..type = json['type'] as String?
-  ..uri = json['uri'] as String?;
+PlayerContext _$PlayerContextFromJson(Map<String, dynamic> json) =>
+    PlayerContext()
+      ..externalUrls = json['external_urls'] == null
+          ? null
+          : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+      ..href = json['href'] as String?
+      ..type = json['type'] as String?
+      ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$PlayerContextToJson(PlayerContext instance) => <String, dynamic>{
+Map<String, dynamic> _$PlayerContextToJson(PlayerContext instance) =>
+    <String, dynamic>{
       'external_urls': instance.externalUrls?.toJson(),
       'href': instance.href,
       'type': instance.type,
@@ -786,12 +868,16 @@ Map<String, dynamic> _$ActionsToJson(Actions instance) => <String, dynamic>{
       'transferring_playback': instance.transferringPlayback,
     };
 
-Map<String, dynamic> _$StartWithContextOptionsToJson(StartWithContextOptions instance) => <String, dynamic>{
+Map<String, dynamic> _$StartWithContextOptionsToJson(
+        StartWithContextOptions instance) =>
+    <String, dynamic>{
       'context_uri': instance.contextUri,
       'offset': StartWithContextOptions._offsetToJson(instance.offset),
     };
 
-Map<String, dynamic> _$StartWithUrisOptionsToJson(StartWithUrisOptions instance) => <String, dynamic>{
+Map<String, dynamic> _$StartWithUrisOptionsToJson(
+        StartWithUrisOptions instance) =>
+    <String, dynamic>{
       'uris': instance.uris,
       'position_ms': instance.positionMs,
     };
@@ -800,115 +886,170 @@ Map<String, dynamic> _$UriOffsetToJson(UriOffset instance) => <String, dynamic>{
       'uri': instance.uri,
     };
 
-Map<String, dynamic> _$PositionOffsetToJson(PositionOffset instance) => <String, dynamic>{
+Map<String, dynamic> _$PositionOffsetToJson(PositionOffset instance) =>
+    <String, dynamic>{
       'position': instance.position,
     };
 
-Playlist _$PlaylistFromJson(Map<String, dynamic> json) => Playlist()
-  ..collaborative = json['collaborative'] as bool?
-  ..description = json['description'] as String?
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
-  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
-  ..href = json['href'] as String?
-  ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
-  ..name = json['name'] as String?
-  ..owner = json['owner'] == null ? null : User.fromJson(json['owner'] as Map<String, dynamic>)
-  ..public = json['public'] as bool?
-  ..snapshotId = json['snapshot_id'] as String?
-  ..tracks = json['tracks'] == null ? null : Paging<Track>.fromJson(json['tracks'] as Map<String, dynamic>)
-  ..type = json['type'] as String?
-  ..uri = json['uri'] as String?;
+PlaylistSimple _$PlaylistSimpleFromJson(Map<String, dynamic> json) =>
+    PlaylistSimple()
+      ..href = json['href'] as String?
+      ..id = json['id'] as String?
+      ..uri = json['uri'] as String?
+      ..type = $enumDecodeNullable(_$SpotifyContentTypeEnumMap, json['type'])
+      ..collaborative = json['collaborative'] as bool?
+      ..description = json['description'] as String?
+      ..externalUrls = json['external_urls'] == null
+          ? null
+          : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+      ..followers = json['followers'] == null
+          ? null
+          : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+      ..images = (json['images'] as List<dynamic>?)
+          ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..name = json['name'] as String?
+      ..owner = json['owner'] == null
+          ? null
+          : User.fromJson(json['owner'] as Map<String, dynamic>)
+      ..public = json['public'] as bool?
+      ..snapshotId = json['snapshot_id'] as String?
+      ..tracks = json['tracks'] == null
+          ? null
+          : TracksLink.fromJson(json['tracks'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PlaylistToJson(Playlist instance) => <String, dynamic>{
+Map<String, dynamic> _$PlaylistSimpleToJson(PlaylistSimple instance) =>
+    <String, dynamic>{
+      'href': instance.href,
+      'id': instance.id,
+      'uri': instance.uri,
+      'type': _$SpotifyContentTypeEnumMap[instance.type],
       'collaborative': instance.collaborative,
       'description': instance.description,
       'external_urls': instance.externalUrls?.toJson(),
       'followers': instance.followers?.toJson(),
-      'href': instance.href,
-      'id': instance.id,
       'images': instance.images?.map((e) => e.toJson()).toList(),
       'name': instance.name,
       'owner': instance.owner?.toJson(),
       'public': instance.public,
       'snapshot_id': instance.snapshotId,
       'tracks': instance.tracks?.toJson(),
-      'type': instance.type,
-      'uri': instance.uri,
     };
 
-PlaylistSimple _$PlaylistSimpleFromJson(Map<String, dynamic> json) => PlaylistSimple()
-  ..collaborative = json['collaborative'] as bool?
-  ..description = json['description'] as String?
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+const _$SpotifyContentTypeEnumMap = {
+  SpotifyContentType.album: 'album',
+  SpotifyContentType.track: 'track',
+  SpotifyContentType.playlist: 'playlist',
+  SpotifyContentType.episode: 'episode',
+  SpotifyContentType.show: 'show',
+};
+
+Playlist _$PlaylistFromJson(Map<String, dynamic> json) => Playlist()
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..uri = json['uri'] as String?
+  ..type = $enumDecodeNullable(_$SpotifyContentTypeEnumMap, json['type'])
+  ..collaborative = json['collaborative'] as bool?
+  ..description = json['description'] as String?
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..followers = json['followers'] == null
+      ? null
+      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..name = json['name'] as String?
-  ..owner = json['owner'] == null ? null : User.fromJson(json['owner'] as Map<String, dynamic>)
+  ..owner = json['owner'] == null
+      ? null
+      : User.fromJson(json['owner'] as Map<String, dynamic>)
   ..public = json['public'] as bool?
   ..snapshotId = json['snapshot_id'] as String?
-  ..tracksLink = json['tracks'] == null ? null : TracksLink.fromJson(json['tracks'] as Map<String, dynamic>)
-  ..type = json['type'] as String?
-  ..uri = json['uri'] as String?;
+  ..tracks = json['tracks'] == null
+      ? null
+      : Paging<Track>.fromJson(json['tracks'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PlaylistSimpleToJson(PlaylistSimple instance) => <String, dynamic>{
+Map<String, dynamic> _$PlaylistToJson(Playlist instance) => <String, dynamic>{
+      'href': instance.href,
+      'id': instance.id,
+      'uri': instance.uri,
+      'type': _$SpotifyContentTypeEnumMap[instance.type],
       'collaborative': instance.collaborative,
       'description': instance.description,
       'external_urls': instance.externalUrls?.toJson(),
-      'href': instance.href,
-      'id': instance.id,
+      'followers': instance.followers?.toJson(),
       'images': instance.images?.map((e) => e.toJson()).toList(),
       'name': instance.name,
       'owner': instance.owner?.toJson(),
       'public': instance.public,
       'snapshot_id': instance.snapshotId,
-      'tracks': instance.tracksLink?.toJson(),
-      'type': instance.type,
-      'uri': instance.uri,
+      'tracks': instance.tracks?.toJson(),
     };
 
 PlaylistsFeatured _$PlaylistsFeaturedFromJson(Map<String, dynamic> json) =>
-    PlaylistsFeatured()..message = json['message'] as String?;
+    PlaylistsFeatured()
+      ..content = json['content'] == null
+          ? null
+          : Playlist.fromJson(json['content'] as Map<String, dynamic>)
+      ..message = json['message'] as String?;
 
-Map<String, dynamic> _$PlaylistsFeaturedToJson(PlaylistsFeatured instance) => <String, dynamic>{
+Map<String, dynamic> _$PlaylistsFeaturedToJson(PlaylistsFeatured instance) =>
+    <String, dynamic>{
+      'content': instance.content?.toJson(),
       'message': instance.message,
     };
 
-PlaylistTrack _$PlaylistTrackFromJson(Map<String, dynamic> json) => PlaylistTrack()
-  ..addedAt = json['added_at'] == null ? null : DateTime.parse(json['added_at'] as String)
-  ..addedBy = json['added_by'] == null ? null : UserPublic.fromJson(json['added_by'] as Map<String, dynamic>)
-  ..isLocal = json['is_local'] as bool?
-  ..track = json['track'] == null ? null : Track.fromJson(json['track'] as Map<String, dynamic>);
+PlaylistTrack _$PlaylistTrackFromJson(Map<String, dynamic> json) =>
+    PlaylistTrack()
+      ..addedAt = json['added_at'] == null
+          ? null
+          : DateTime.parse(json['added_at'] as String)
+      ..addedBy = json['added_by'] == null
+          ? null
+          : UserPublic.fromJson(json['added_by'] as Map<String, dynamic>)
+      ..isLocal = json['is_local'] as bool?
+      ..track = json['track'] == null
+          ? null
+          : Track.fromJson(json['track'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PlaylistTrackToJson(PlaylistTrack instance) => <String, dynamic>{
+Map<String, dynamic> _$PlaylistTrackToJson(PlaylistTrack instance) =>
+    <String, dynamic>{
       'added_at': instance.addedAt?.toIso8601String(),
       'added_by': instance.addedBy?.toJson(),
       'is_local': instance.isLocal,
       'track': instance.track?.toJson(),
     };
 
-Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) => Recommendations()
-  ..seeds =
-      (json['seeds'] as List<dynamic>?)?.map((e) => RecommendationsSeed.fromJson(e as Map<String, dynamic>)).toList()
-  ..tracks = (json['tracks'] as List<dynamic>?)?.map((e) => Track.fromJson(e as Map<String, dynamic>)).toList();
+Recommendations _$RecommendationsFromJson(Map<String, dynamic> json) =>
+    Recommendations()
+      ..seeds = (json['seeds'] as List<dynamic>?)
+          ?.map((e) => RecommendationsSeed.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..tracks = (json['tracks'] as List<dynamic>?)
+          ?.map((e) => Track.fromJson(e as Map<String, dynamic>))
+          .toList();
 
-Map<String, dynamic> _$RecommendationsToJson(Recommendations instance) => <String, dynamic>{
+Map<String, dynamic> _$RecommendationsToJson(Recommendations instance) =>
+    <String, dynamic>{
       'seeds': instance.seeds?.map((e) => e.toJson()).toList(),
       'tracks': instance.tracks?.map((e) => e.toJson()).toList(),
     };
 
-RecommendationsSeed _$RecommendationsSeedFromJson(Map<String, dynamic> json) => RecommendationsSeed()
-  ..afterFilteringSize = convertToIntIfDoubleValue(json['afterFilteringSize'])
-  ..afterRelinkingSize = convertToIntIfDoubleValue(json['afterRelinkingSize'])
-  ..href = json['href'] as String?
-  ..id = json['id'] as String?
-  ..initialPoolSize = convertToIntIfDoubleValue(json['initialPoolSize'])
-  ..type = json['type'] as String?;
+RecommendationsSeed _$RecommendationsSeedFromJson(Map<String, dynamic> json) =>
+    RecommendationsSeed()
+      ..afterFilteringSize =
+          convertToIntIfDoubleValue(json['afterFilteringSize'])
+      ..afterRelinkingSize =
+          convertToIntIfDoubleValue(json['afterRelinkingSize'])
+      ..href = json['href'] as String?
+      ..id = json['id'] as String?
+      ..initialPoolSize = convertToIntIfDoubleValue(json['initialPoolSize'])
+      ..type = json['type'] as String?;
 
-Map<String, dynamic> _$RecommendationsSeedToJson(RecommendationsSeed instance) => <String, dynamic>{
+Map<String, dynamic> _$RecommendationsSeedToJson(
+        RecommendationsSeed instance) =>
+    <String, dynamic>{
       'afterFilteringSize': instance.afterFilteringSize,
       'afterRelinkingSize': instance.afterRelinkingSize,
       'href': instance.href,
@@ -918,42 +1059,51 @@ Map<String, dynamic> _$RecommendationsSeedToJson(RecommendationsSeed instance) =
     };
 
 Show _$ShowFromJson(Map<String, dynamic> json) => Show()
-  ..availableMarkets =
-      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
-  ..copyrights =
-      (json['copyrights'] as List<dynamic>?)?.map((e) => Copyright.fromJson(e as Map<String, dynamic>)).toList()
-  ..description = json['description'] as String?
-  ..explicit = json['explicit'] as bool?
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..uri = json['uri'] as String?
+  ..type = $enumDecodeNullable(_$SpotifyContentTypeEnumMap, json['type'])
+  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
+      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
+      .toList()
+  ..copyrights = (json['copyrights'] as List<dynamic>?)
+      ?.map((e) => Copyright.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..description = json['description'] as String?
+  ..explicit = json['explicit'] as bool?
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..isExternallyHosted = json['is_externally_hosted'] as bool?
-  ..languages = (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..languages =
+      (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..mediaType = json['media_type'] as String?
   ..name = json['name'] as String?
   ..publisher = json['publisher'] as String?
-  ..type = json['type'] as String?
-  ..uri = json['uri'] as String?
-  ..totalEpisodes = json['total_episodes'] == null ? 0 : convertToIntIfDoubleValue(json['total_episodes']);
+  ..totalEpisodes = json['total_episodes'] == null
+      ? 0
+      : convertToIntIfDoubleValue(json['total_episodes']);
 
 Map<String, dynamic> _$ShowToJson(Show instance) => <String, dynamic>{
-      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'href': instance.href,
+      'id': instance.id,
+      'uri': instance.uri,
+      'type': _$SpotifyContentTypeEnumMap[instance.type],
+      'available_markets':
+          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'copyrights': instance.copyrights?.map((e) => e.toJson()).toList(),
       'description': instance.description,
       'explicit': instance.explicit,
       'external_urls': instance.externalUrls?.toJson(),
-      'href': instance.href,
-      'id': instance.id,
       'images': instance.images?.map((e) => e.toJson()).toList(),
       'is_externally_hosted': instance.isExternallyHosted,
       'languages': instance.languages,
       'media_type': instance.mediaType,
       'name': instance.name,
       'publisher': instance.publisher,
-      'type': instance.type,
-      'uri': instance.uri,
       'total_episodes': instance.totalEpisodes,
     };
 
@@ -962,17 +1112,23 @@ Episode _$EpisodeFromJson(Map<String, dynamic> json) => Episode()
   ..description = json['description'] as String?
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..isExternallyHosted = json['is_externally_hosted'] as bool?
   ..isPlayable = json['is_playable'] as bool?
   ..language = json['language'] as String?
-  ..languages = (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..languages =
+      (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..name = json['name'] as String?
-  ..releaseDate = json['release_date'] == null ? null : DateTime.parse(json['release_date'] as String)
+  ..releaseDate = json['release_date'] == null
+      ? null
+      : DateTime.parse(json['release_date'] as String)
   ..releaseDatePrecision = json['release_date_precision'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
@@ -1002,23 +1158,32 @@ EpisodeFull _$EpisodeFullFromJson(Map<String, dynamic> json) => EpisodeFull()
   ..description = json['description'] as String?
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..isExternallyHosted = json['is_externally_hosted'] as bool?
   ..isPlayable = json['is_playable'] as bool?
   ..language = json['language'] as String?
-  ..languages = (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
+  ..languages =
+      (json['languages'] as List<dynamic>?)?.map((e) => e as String).toList()
   ..name = json['name'] as String?
-  ..releaseDate = json['release_date'] == null ? null : DateTime.parse(json['release_date'] as String)
+  ..releaseDate = json['release_date'] == null
+      ? null
+      : DateTime.parse(json['release_date'] as String)
   ..releaseDatePrecision = json['release_date_precision'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?
-  ..show = json['show'] == null ? null : Show.fromJson(json['show'] as Map<String, dynamic>);
+  ..show = json['show'] == null
+      ? null
+      : Show.fromJson(json['show'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$EpisodeFullToJson(EpisodeFull instance) => <String, dynamic>{
+Map<String, dynamic> _$EpisodeFullToJson(EpisodeFull instance) =>
+    <String, dynamic>{
       'audio_preview_url': instance.audioPreviewUrl,
       'description': instance.description,
       'duration_ms': instance.durationMs,
@@ -1040,21 +1205,30 @@ Map<String, dynamic> _$EpisodeFullToJson(EpisodeFull instance) => <String, dynam
     };
 
 Track _$TrackFromJson(Map<String, dynamic> json) => Track()
-  ..album = json['album'] == null ? null : AlbumSimple.fromJson(json['album'] as Map<String, dynamic>)
-  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => Artist.fromJson(e as Map<String, dynamic>)).toList()
-  ..availableMarkets =
-      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
+  ..album = json['album'] == null
+      ? null
+      : AlbumSimple.fromJson(json['album'] as Map<String, dynamic>)
+  ..artists = (json['artists'] as List<dynamic>?)
+      ?.map((e) => Artist.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
+      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
+      .toList()
   ..discNumber = convertToIntIfDoubleValue(json['disc_number'])
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalIds =
-      json['external_ids'] == null ? null : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalIds = json['external_ids'] == null
+      ? null
+      : ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>)
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..isPlayable = json['is_playable'] as bool?
-  ..linkedFrom = json['linked_from'] == null ? null : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
+  ..linkedFrom = json['linked_from'] == null
+      ? null
+      : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
   ..name = json['name'] as String?
   ..popularity = convertToIntIfDoubleValue(json['popularity'])
   ..previewUrl = json['preview_url'] as String?
@@ -1065,7 +1239,8 @@ Track _$TrackFromJson(Map<String, dynamic> json) => Track()
 Map<String, dynamic> _$TrackToJson(Track instance) => <String, dynamic>{
       'album': instance.album?.toJson(),
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets':
+          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'disc_number': instance.discNumber,
       'duration_ms': instance.durationMs,
       'explicit': instance.explicit,
@@ -1084,27 +1259,35 @@ Map<String, dynamic> _$TrackToJson(Track instance) => <String, dynamic>{
     };
 
 TrackSimple _$TrackSimpleFromJson(Map<String, dynamic> json) => TrackSimple()
-  ..artists = (json['artists'] as List<dynamic>?)?.map((e) => Artist.fromJson(e as Map<String, dynamic>)).toList()
-  ..availableMarkets =
-      (json['available_markets'] as List<dynamic>?)?.map((e) => $enumDecode(_$MarketEnumMap, e)).toList()
+  ..artists = (json['artists'] as List<dynamic>?)
+      ?.map((e) => Artist.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..availableMarkets = (json['available_markets'] as List<dynamic>?)
+      ?.map((e) => $enumDecode(_$MarketEnumMap, e))
+      .toList()
   ..discNumber = convertToIntIfDoubleValue(json['disc_number'])
   ..durationMs = convertToIntIfDoubleValue(json['duration_ms'])
   ..explicit = json['explicit'] as bool?
-  ..externalUrls =
-      json['external_urls'] == null ? null : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
+  ..externalUrls = json['external_urls'] == null
+      ? null
+      : ExternalUrls.fromJson(json['external_urls'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
   ..isPlayable = json['is_playable'] as bool?
-  ..linkedFrom = json['linked_from'] == null ? null : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
+  ..linkedFrom = json['linked_from'] == null
+      ? null
+      : TrackLink.fromJson(json['linked_from'] as Map<String, dynamic>)
   ..name = json['name'] as String?
   ..previewUrl = json['preview_url'] as String?
   ..trackNumber = convertToIntIfDoubleValue(json['track_number'])
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) => <String, dynamic>{
+Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) =>
+    <String, dynamic>{
       'artists': instance.artists?.map((e) => e.toJson()).toList(),
-      'available_markets': instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
+      'available_markets':
+          instance.availableMarkets?.map((e) => _$MarketEnumMap[e]!).toList(),
       'disc_number': instance.discNumber,
       'duration_ms': instance.durationMs,
       'explicit': instance.explicit,
@@ -1121,10 +1304,15 @@ Map<String, dynamic> _$TrackSimpleToJson(TrackSimple instance) => <String, dynam
     };
 
 TrackSaved _$TrackSavedFromJson(Map<String, dynamic> json) => TrackSaved()
-  ..addedAt = json['added_at'] == null ? null : DateTime.parse(json['added_at'] as String)
-  ..track = json['track'] == null ? null : Track.fromJson(json['track'] as Map<String, dynamic>);
+  ..addedAt = json['added_at'] == null
+      ? null
+      : DateTime.parse(json['added_at'] as String)
+  ..track = json['track'] == null
+      ? null
+      : Track.fromJson(json['track'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$TrackSavedToJson(TrackSaved instance) => <String, dynamic>{
+Map<String, dynamic> _$TrackSavedToJson(TrackSaved instance) =>
+    <String, dynamic>{
       'added_at': instance.addedAt?.toIso8601String(),
       'track': instance.track?.toJson(),
     };
@@ -1150,7 +1338,8 @@ TracksLink _$TracksLinkFromJson(Map<String, dynamic> json) => TracksLink()
   ..href = json['href'] as String?
   ..total = convertToIntIfDoubleValue(json['total']);
 
-Map<String, dynamic> _$TracksLinkToJson(TracksLink instance) => <String, dynamic>{
+Map<String, dynamic> _$TracksLinkToJson(TracksLink instance) =>
+    <String, dynamic>{
       'href': instance.href,
       'total': instance.total,
     };
@@ -1160,10 +1349,14 @@ User _$UserFromJson(Map<String, dynamic> json) => User()
   ..country = $enumDecodeNullable(_$MarketEnumMap, json['country'])
   ..displayName = json['display_name'] as String?
   ..email = json['email'] as String?
-  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..followers = json['followers'] == null
+      ? null
+      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..product = json['product'] as String?
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
@@ -1184,14 +1377,19 @@ Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
 
 UserPublic _$UserPublicFromJson(Map<String, dynamic> json) => UserPublic()
   ..displayName = json['display_name'] as String?
-  ..followers = json['followers'] == null ? null : Followers.fromJson(json['followers'] as Map<String, dynamic>)
+  ..followers = json['followers'] == null
+      ? null
+      : Followers.fromJson(json['followers'] as Map<String, dynamic>)
   ..href = json['href'] as String?
   ..id = json['id'] as String?
-  ..images = (json['images'] as List<dynamic>?)?.map((e) => Image.fromJson(e as Map<String, dynamic>)).toList()
+  ..images = (json['images'] as List<dynamic>?)
+      ?.map((e) => Image.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..type = json['type'] as String?
   ..uri = json['uri'] as String?;
 
-Map<String, dynamic> _$UserPublicToJson(UserPublic instance) => <String, dynamic>{
+Map<String, dynamic> _$UserPublicToJson(UserPublic instance) =>
+    <String, dynamic>{
       'display_name': instance.displayName,
       'followers': instance.followers?.toJson(),
       'href': instance.href,
@@ -1202,20 +1400,30 @@ Map<String, dynamic> _$UserPublicToJson(UserPublic instance) => <String, dynamic
     };
 
 PlayHistory _$PlayHistoryFromJson(Map<String, dynamic> json) => PlayHistory()
-  ..track = json['track'] == null ? null : Track.fromJson(json['track'] as Map<String, dynamic>)
-  ..playedAt = json['played_at'] == null ? null : DateTime.parse(json['played_at'] as String)
-  ..context = json['context'] == null ? null : PlayerContext.fromJson(json['context'] as Map<String, dynamic>);
+  ..track = json['track'] == null
+      ? null
+      : Track.fromJson(json['track'] as Map<String, dynamic>)
+  ..playedAt = json['played_at'] == null
+      ? null
+      : DateTime.parse(json['played_at'] as String)
+  ..context = json['context'] == null
+      ? null
+      : PlayerContext.fromJson(json['context'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PlayHistoryToJson(PlayHistory instance) => <String, dynamic>{
+Map<String, dynamic> _$PlayHistoryToJson(PlayHistory instance) =>
+    <String, dynamic>{
       'track': instance.track?.toJson(),
       'played_at': instance.playedAt?.toIso8601String(),
       'context': instance.context?.toJson(),
     };
 
 Queue _$QueueFromJson(Map<String, dynamic> json) => Queue()
-  ..currentlyPlaying =
-      json['currently_playing'] == null ? null : Track.fromJson(json['currently_playing'] as Map<String, dynamic>)
-  ..queue = (json['queue'] as List<dynamic>?)?.map((e) => Track.fromJson(e as Map<String, dynamic>)).toList();
+  ..currentlyPlaying = json['currently_playing'] == null
+      ? null
+      : Track.fromJson(json['currently_playing'] as Map<String, dynamic>)
+  ..queue = (json['queue'] as List<dynamic>?)
+      ?.map((e) => Track.fromJson(e as Map<String, dynamic>))
+      .toList();
 
 Map<String, dynamic> _$QueueToJson(Queue instance) => <String, dynamic>{
       'currently_playing': instance.currentlyPlaying?.toJson(),

--- a/lib/src/models/playlist.dart
+++ b/lib/src/models/playlist.dart
@@ -3,161 +3,78 @@
 
 part of '_models.dart';
 
-/// Json representation of a playlist
-@JsonSerializable()
-class Playlist extends Object implements PlaylistSimple {
-  Playlist();
-
-  factory Playlist.fromJson(Map<String, dynamic> json) => _$PlaylistFromJson(json);
-
-  @override
-  Map<String, dynamic> toJson() => _$PlaylistToJson(this);
-
-  /// true if the owner allows other users to modify the playlist.
-  @override
+class PlaylistBase<T> extends SpotifyContent {
+  /// `true` if the owner allows other users to modify the playlist.
   bool? collaborative;
 
   /// The playlist description. Only returned for modified, verified playlists,
   /// otherwise `null`.
-  @override
   String? description;
 
   /// Known external URLs for this playlist.
   @JsonKey(name: 'external_urls')
-  @override
   ExternalUrls? externalUrls;
 
   /// Information about the followers of the playlist.
   Followers? followers;
 
-  /// A link to the Web API endpoint providing full details of the playlist.
-  @override
-  String? href;
-
-  /// The Spotify ID for the playlist.
-  @override
-  String? id;
-
   /// Images for the playlist. The array may be empty or contain up to three
   /// images. The images are returned by size in descending order. See Working
   /// with Playlists.
   ///
   /// Note: If returned, the source URL for the image (url) is temporary and
   /// will expire in less than a day.
-  @override
   List<Image>? images;
 
   /// The name of the playlist.
-  @override
   String? name;
 
   /// The user who owns the playlist
-  @override
   User? owner;
 
   /// The playlist's public/private status: `true` the playlist is public,
   /// `false` the playlist is private, null the playlist status is not relevant.
   /// For more about public/private status, see Working with Playlists.
-  @override
   bool? public;
 
   /// The version identifier for the current playlist. Can be supplied in other
   /// requests to target a specific playlist version
   @JsonKey(name: 'snapshot_id')
-  @override
   String? snapshotId;
 
-  /// Use [Playlist.tracks]
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  TracksLink? tracksLink;
-
   /// Information about the tracks of the playlist.
-  Paging<Track>? tracks;
-
-  /// The object type: "playlist"
-  @override
-  String? type;
-
-  /// The Spotify URI for the playlist.
-  @override
-  String? uri;
+  @JsonKey(name: 'tracks')
+  T? tracks;
 }
 
 /// Json representation of a simplified playlist
 @JsonSerializable()
-class PlaylistSimple extends Object {
+class PlaylistSimple extends PlaylistBase<TracksLink> {
   PlaylistSimple();
 
   factory PlaylistSimple.fromJson(Map<String, dynamic> json) => _$PlaylistSimpleFromJson(json);
 
   Map<String, dynamic> toJson() => _$PlaylistSimpleToJson(this);
+}
 
-  /// true if the owner allows other users to modify the playlist.
-  bool? collaborative;
+/// Json representation of a playlist
+@JsonSerializable()
+class Playlist extends PlaylistBase<Paging<Track>> {
+  Playlist();
 
-  /// The playlist description. Only returned for modified, verified playlists,
-  /// otherwise `null`.
-  String? description;
+  factory Playlist.fromJson(Map<String, dynamic> json) => _$PlaylistFromJson(json);
 
-  /// Known external URLs for this playlist.
-  @JsonKey(name: 'external_urls')
-  ExternalUrls? externalUrls;
-
-  /// A link to the Web API endpoint providing full details of the playlist.
-  String? href;
-
-  /// The Spotify ID for the playlist.
-  String? id;
-
-  /// Images for the playlist. The array may be empty or contain up to three
-  /// images. The images are returned by size in descending order. See Working
-  /// with Playlists.
-  ///
-  /// Note: If returned, the source URL for the image (url) is temporary and
-  /// will expire in less than a day.
-  List<Image>? images;
-
-  /// The name of the playlist.
-  String? name;
-
-  /// The user who owns the playlist
-  User? owner;
-
-  /// The playlist's public/private status: `true` the playlist is public,
-  /// `false` the playlist is private, null the playlist status is not relevant.
-  /// For more about public/private status, see Working with Playlists.
-  bool? public;
-
-  /// The version identifier for the current playlist. Can be supplied in other
-  /// requests to target a specific playlist version
-  @JsonKey(name: 'snapshot_id')
-  String? snapshotId;
-
-  /// A collection containing a link (href) to the Web API endpoint where full
-  /// details of the playlist's tracks can be retrieved, along with the total
-  /// number of tracks in the playlist.
-  @JsonKey(name: 'tracks')
-  TracksLink? tracksLink;
-
-  /// The object type: "playlist"
-  String? type;
-
-  /// The Spotify URI for the playlist.
-  String? uri;
+  Map<String, dynamic> toJson() => _$PlaylistToJson(this);
 }
 
 /// Json representation of a featured playlist. Used as a wrapper object.
 @JsonSerializable()
-class PlaylistsFeatured extends Object {
+class PlaylistsFeatured extends FeaturedContent<Playlist> {
   PlaylistsFeatured();
 
   factory PlaylistsFeatured.fromJson(Map<String, dynamic> json) => _$PlaylistsFeaturedFromJson(json);
 
   Map<String, dynamic> toJson() => _$PlaylistsFeaturedToJson(this);
-
-  /// The message of the day for Spotify's featured playlists
-  String? message;
 }
 
 /// Json representation of a playlist with a single track

--- a/lib/src/models/show.dart
+++ b/lib/src/models/show.dart
@@ -5,7 +5,7 @@ part of '_models.dart';
 
 /// Json representation of a show
 @JsonSerializable()
-class Show {
+class Show extends SpotifyContent {
   Show();
 
   /// The markets in which the show is available: ISO 3166-1 alpha-2 country
@@ -28,12 +28,6 @@ class Show {
   @JsonKey(name: 'external_urls')
   ExternalUrls? externalUrls;
 
-  /// A link to the Web API endpoint providing full details of the show.
-  String? href;
-
-  /// The Spotify ID for the show.
-  String? id;
-
   /// The cover art for the show in various sizes, widest first.
   List<Image>? images;
 
@@ -54,12 +48,6 @@ class Show {
 
   /// The publisher of the show.
   String? publisher;
-
-  /// The object type: "show"
-  String? type;
-
-  /// The Spotify URI for the show.
-  String? uri;
 
   /// The number of total episodes in this show
   @JsonKey(

--- a/test/me_test.dart
+++ b/test/me_test.dart
@@ -131,7 +131,7 @@ Future main() async {
         expect(result.items!.length, 2);
 
         final firstShow = result.items!.first;
-        expect(firstShow.type, 'show');
+        expect(firstShow.type, SpotifyContentType.show);
         expect(firstShow.name != null, true);
         expect(firstShow.id, '4XPl3uEEL9hvqMkoZrzbx5');
       });

--- a/test/shows_test.dart
+++ b/test/shows_test.dart
@@ -15,7 +15,7 @@ Future main() async {
     test('get', () async {
       final show = await spotify.shows.get('4AlxqGkkrqe0mfIx3Mi7Xt');
 
-      expect(show.type, 'show');
+      expect(show.type, SpotifyContentType.show);
       expect(show.id, '4AlxqGkkrqe0mfIx3Mi7Xt');
       expect(show.name, 'Universo Flutter');
       expect(show.totalEpisodes, 26);


### PR DESCRIPTION
This PR is a series of PR's that refactors the model classes as explained in #172 .

It includes the following model classes:
- [x] PlaylistSimple
- [x] Playlist
- [x] Show

# Breaking change 🚨

The `String? type` is now a `SpotifyContentType`, which causes compile errors on library users

In order to prevent that, we could either
1. keep `String? type`
2. Remove the `type` member completely

