### PR TITLE
Resume `stream()` issue

### DIFF
--- a/lib/src/endpoints/endpoint_paging.dart
+++ b/lib/src/endpoints/endpoint_paging.dart
@@ -250,8 +250,9 @@ abstract class SinglePages<T, V extends BasePage<T>> extends _Pages implements N
 
     stream = StreamController<V>(
       onListen: () {
+        _cancelled = false;
         Future<V> firstPage;
-        if (_bufferedPages.length == 1) {
+        if (_bufferedPages.isNotEmpty) {
           firstPage = Future.value(_bufferedPages.removeAt(0));
         } else {
           firstPage = first(limit);
@@ -263,11 +264,17 @@ abstract class SinglePages<T, V extends BasePage<T>> extends _Pages implements N
         return;
       },
       onResume: () {
+        if (_bufferedPages.isEmpty) {
+          return;
+        }
+
+        final isLastPage = _bufferedPages.last.isLast;
         _bufferedPages.forEach(stream.add);
-        if (_bufferedPages.last.isLast) {
+        _bufferedPages.clear();
+
+        if (isLastPage) {
           stream.close();
         }
-        _bufferedPages.clear();
       },
     );
     return stream.stream;

--- a/test/playlists_test.dart
+++ b/test/playlists_test.dart
@@ -86,5 +86,20 @@ Future main() async {
         ),
       );
     });
+
+    test('getUsersPlaylists stream pause and resume before first page', () async {
+      final playlists = spotify.playlists.getUsersPlaylists('X123Y');
+      final received = <Page<PlaylistSimple>>[];
+
+      final subscription = playlists.stream().listen(received.add);
+      subscription.pause();
+      subscription.resume();
+
+      await subscription.asFuture<void>();
+      await subscription.cancel();
+
+      expect(received, hasLength(1));
+      expect(received.single.items, hasLength(2));
+    });
   });
 }


### PR DESCRIPTION
So I ran the `endpoint_paging` through Codex, and it found an interesting issue:

- the `onResume` calls `_bufferedPages.last` without checking whether the buffer is empty.
- `_cancelled` is never reset, so reusing the same pager after cancellation could behave oddly.

And it fixed the following

- `_cancelled` is reset, each time when a new stream starts
- pages is reused, whenever the buffer is non-empty, not only when it has exactly one item 
- `onResume` is now guarded against an empty buffer before touching `_bufferedPages.last`